### PR TITLE
[codex] Add curated poetry analysis feedback loop

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,12 +8,17 @@
  * @module
  */
 
+import type * as deepPoemAnalyses from "../deepPoemAnalyses.js";
+import type * as deepPoemAnalysisAction from "../deepPoemAnalysisAction.js";
 import type * as generate from "../generate.js";
 import type * as generateImage from "../generateImage.js";
 import type * as imageStyles from "../imageStyles.js";
 import type * as initPoem from "../initPoem.js";
 import type * as migrations from "../migrations.js";
+import type * as poemAnalyses from "../poemAnalyses.js";
 import type * as poems from "../poems.js";
+import type * as poetryModelConfig from "../poetryModelConfig.js";
+import type * as promptLearning from "../promptLearning.js";
 import type * as rateLimiter from "../rateLimiter.js";
 import type * as requestImage from "../requestImage.js";
 import type * as stylesConfig from "../stylesConfig.js";
@@ -26,12 +31,17 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  deepPoemAnalyses: typeof deepPoemAnalyses;
+  deepPoemAnalysisAction: typeof deepPoemAnalysisAction;
   generate: typeof generate;
   generateImage: typeof generateImage;
   imageStyles: typeof imageStyles;
   initPoem: typeof initPoem;
   migrations: typeof migrations;
+  poemAnalyses: typeof poemAnalyses;
   poems: typeof poems;
+  poetryModelConfig: typeof poetryModelConfig;
+  promptLearning: typeof promptLearning;
   rateLimiter: typeof rateLimiter;
   requestImage: typeof requestImage;
   stylesConfig: typeof stylesConfig;

--- a/convex/deepPoemAnalyses.ts
+++ b/convex/deepPoemAnalyses.ts
@@ -1,0 +1,170 @@
+import { v } from 'convex/values';
+import { internalMutation, internalQuery, mutation } from './_generated/server';
+import { api, internal } from './_generated/api';
+import { Id } from './_generated/dataModel';
+import { STYLES } from './stylesConfig';
+import { DEEP_ANALYSIS_MODEL_CONFIG } from './poetryModelConfig';
+import { DEEP_ANALYSIS_VERSION } from '../src/lib/poetry/analysisTypes';
+import { ANALYSIS_VERSION } from '../src/lib/poetry/analyzePoem';
+
+type RequestDeepAnalysisResult =
+  | { success: true; analysisId: Id<'poemDeepAnalyses'> }
+  | { success: false; error: string };
+
+export const getForDeepAnalysis = internalQuery({
+  args: {
+    poemId: v.id('poems'),
+  },
+  handler: async (ctx, args) => {
+    const poem = await ctx.db.get(args.poemId);
+    if (!poem) return null;
+
+    const topic = await ctx.db.get(poem.topicId);
+    const style = STYLES.find((candidate) => candidate.name === poem.styleName);
+    const ruleAnalysis = await ctx.db
+      .query('poemAnalyses')
+      .withIndex('by_poem_version', (q) =>
+        q.eq('poemId', args.poemId).eq('analysisVersion', ANALYSIS_VERSION),
+      )
+      .unique();
+
+    return {
+      title: poem.title,
+      lines: poem.lines,
+      status: poem.status,
+      styleName: poem.styleName,
+      styleExplanation: style?.userExplanation ?? '',
+      topicName: topic?.name ?? '',
+      ruleAnalysisJson: ruleAnalysis?.reportJson ?? null,
+    };
+  },
+});
+
+export const requestDeepAnalysis = mutation({
+  args: {
+    poemId: v.id('poems'),
+    identifier: v.string(),
+  },
+  handler: async (ctx, args): Promise<RequestDeepAnalysisResult> => {
+    const poem = await ctx.db.get(args.poemId);
+    if (!poem) return { success: false, error: 'Poem not found.' };
+    if (poem.status !== 'complete') {
+      return { success: false, error: 'Poem must be complete before deep analysis.' };
+    }
+
+    const existing = await ctx.db
+      .query('poemDeepAnalyses')
+      .withIndex('by_poem_version', (q) =>
+        q.eq('poemId', args.poemId).eq('analysisVersion', DEEP_ANALYSIS_VERSION),
+      )
+      .unique();
+
+    if (existing && existing.status !== 'error') {
+      return { success: true, analysisId: existing._id };
+    }
+
+    const rateLimitResult = await ctx.runMutation(api.rateLimiter.checkRateLimit, {
+      identifier: args.identifier,
+      kind: 'deepAnalysis',
+    });
+    if (!rateLimitResult.allowed) {
+      return {
+        success: false,
+        error: 'You have reached the daily deep analysis limit. Try again tomorrow!',
+      };
+    }
+
+    const now = Date.now();
+    const payload = {
+      poemId: args.poemId,
+      analysisVersion: DEEP_ANALYSIS_VERSION,
+      model: DEEP_ANALYSIS_MODEL_CONFIG.model,
+      modelProvider: DEEP_ANALYSIS_MODEL_CONFIG.provider,
+      gatewayModelId: DEEP_ANALYSIS_MODEL_CONFIG.gatewayModelId,
+      promptVersion: DEEP_ANALYSIS_MODEL_CONFIG.promptVersion,
+      status: 'pending' as const,
+      requestedAt: now,
+      updatedAt: now,
+    };
+
+    const analysisId = existing
+      ? existing._id
+      : await ctx.db.insert('poemDeepAnalyses', payload);
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        ...payload,
+        reportJson: undefined,
+        error: undefined,
+        completedAt: undefined,
+      });
+    }
+
+    await ctx.scheduler.runAfter(0, internal.deepPoemAnalysisAction.runDeepAnalysis, {
+      analysisId,
+      poemId: args.poemId,
+    });
+
+    return { success: true, analysisId };
+  },
+});
+
+export const markDeepAnalysisGenerating = internalMutation({
+  args: {
+    analysisId: v.id('poemDeepAnalyses'),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.analysisId, {
+      status: 'generating',
+      updatedAt: Date.now(),
+      error: undefined,
+    });
+  },
+});
+
+export const storeDeepAnalysis = internalMutation({
+  args: {
+    analysisId: v.id('poemDeepAnalyses'),
+    reportJson: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.patch(args.analysisId, {
+      status: 'complete',
+      reportJson: args.reportJson,
+      error: undefined,
+      updatedAt: now,
+      completedAt: now,
+    });
+  },
+});
+
+export const setDeepAnalysisError = internalMutation({
+  args: {
+    analysisId: v.id('poemDeepAnalyses'),
+    error: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.analysisId, {
+      status: 'error',
+      error: args.error,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const clearForPoem = internalMutation({
+  args: {
+    poemId: v.id('poems'),
+  },
+  handler: async (ctx, args) => {
+    const analyses = await ctx.db
+      .query('poemDeepAnalyses')
+      .filter((q) => q.eq(q.field('poemId'), args.poemId))
+      .collect();
+
+    for (const analysis of analyses) {
+      await ctx.db.delete(analysis._id);
+    }
+  },
+});

--- a/convex/deepPoemAnalysisAction.ts
+++ b/convex/deepPoemAnalysisAction.ts
@@ -1,0 +1,142 @@
+'use node';
+
+import { generateText } from 'ai';
+import { v } from 'convex/values';
+import { internalAction } from './_generated/server';
+import { internal } from './_generated/api';
+import { DEEP_ANALYSIS_MODEL_CONFIG } from './poetryModelConfig';
+import {
+  AnalysisConfidence,
+  DeepVerseAnalysisReport,
+} from '../src/lib/poetry/analysisTypes';
+
+function buildDeepAnalysisPrompt(args: {
+  title: string;
+  lines: string[];
+  styleName: string;
+  styleExplanation: string;
+  topicName: string;
+  ruleAnalysisJson: string | null;
+}): string {
+  const poemText = [`Title: ${args.title}`, '', ...args.lines].join('\n');
+
+  return `Analyze this AI-generated poem as a literary critic and verse-form specialist.
+
+This is a deep qualitative analysis. The rule-based report, if present, is the transparent baseline; do not replace it or pretend meter/rhyme detection is certain.
+
+Poetic form: ${args.styleName}
+Form notes: ${args.styleExplanation || 'No extra form notes provided.'}
+Topic: ${args.topicName || 'Unknown'}
+
+Poem:
+${poemText}
+
+Rule-based analysis JSON:
+${args.ruleAnalysisJson ?? 'No rule-based analysis is available.'}
+
+Return only JSON in this exact shape:
+{
+  "styleName": "${args.styleName}",
+  "overallAssessment": "2-4 sentences on how the poem works as a poem and as an attempt at the requested form.",
+  "formalReading": "2-4 sentences interpreting form, structure, turns, repetition, rhythm, and visible constraint handling.",
+  "imageryAndVoice": "2-4 sentences on imagery, diction, tone, argument, and poetic force.",
+  "strengths": ["specific strength 1", "specific strength 2", "specific strength 3"],
+  "weaknesses": ["specific weakness 1", "specific weakness 2", "specific weakness 3"],
+  "revisionPriorities": ["specific revision priority 1", "specific revision priority 2", "specific revision priority 3"],
+  "confidence": "low"
+}
+
+Set confidence to "low", "medium", or "high". Be candid, specific, and concise.`;
+}
+
+function parseJsonObject(text: string): unknown {
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  return JSON.parse(jsonMatch[0]);
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 6);
+}
+
+function readConfidence(value: unknown): AnalysisConfidence {
+  return value === 'low' || value === 'medium' || value === 'high' ? value : 'low';
+}
+
+function parseDeepAnalysisReport(text: string, styleName: string): DeepVerseAnalysisReport {
+  const parsed = parseJsonObject(text);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Model did not return a JSON object.');
+  }
+
+  const record = parsed as Record<string, unknown>;
+  return {
+    styleName,
+    overallAssessment: readString(
+      record.overallAssessment,
+      'The model did not provide an overall assessment.',
+    ),
+    formalReading: readString(
+      record.formalReading,
+      'The model did not provide a formal reading.',
+    ),
+    imageryAndVoice: readString(
+      record.imageryAndVoice,
+      'The model did not provide an imagery and voice reading.',
+    ),
+    strengths: readStringArray(record.strengths),
+    weaknesses: readStringArray(record.weaknesses),
+    revisionPriorities: readStringArray(record.revisionPriorities),
+    confidence: readConfidence(record.confidence),
+  };
+}
+
+export const runDeepAnalysis = internalAction({
+  args: {
+    analysisId: v.id('poemDeepAnalyses'),
+    poemId: v.id('poems'),
+  },
+  handler: async (ctx, args) => {
+    await ctx.runMutation(internal.deepPoemAnalyses.markDeepAnalysisGenerating, {
+      analysisId: args.analysisId,
+    });
+
+    try {
+      const poem = await ctx.runQuery(internal.deepPoemAnalyses.getForDeepAnalysis, {
+        poemId: args.poemId,
+      });
+      if (!poem || poem.status !== 'complete') {
+        throw new Error('Poem is not complete.');
+      }
+
+      const { text } = await generateText({
+        model: DEEP_ANALYSIS_MODEL_CONFIG.model,
+        maxOutputTokens: DEEP_ANALYSIS_MODEL_CONFIG.maxOutputTokens,
+        temperature: DEEP_ANALYSIS_MODEL_CONFIG.temperature,
+        system:
+          'You are a precise literary critic. You analyze poems with generosity, candor, and technical specificity. Return valid JSON only.',
+        prompt: buildDeepAnalysisPrompt(poem),
+      });
+
+      const report = parseDeepAnalysisReport(text, poem.styleName);
+      await ctx.runMutation(internal.deepPoemAnalyses.storeDeepAnalysis, {
+        analysisId: args.analysisId,
+        reportJson: JSON.stringify(report),
+      });
+    } catch (error) {
+      await ctx.runMutation(internal.deepPoemAnalyses.setDeepAnalysisError, {
+        analysisId: args.analysisId,
+        error: error instanceof Error ? error.message : 'Deep analysis failed.',
+      });
+    }
+  },
+});

--- a/convex/generate.ts
+++ b/convex/generate.ts
@@ -5,16 +5,7 @@ import { v } from 'convex/values';
 import { internal } from './_generated/api';
 import { streamText } from 'ai';
 import { tryParseJson, tryParsePartialJson } from '../src/lib/poemParsing';
-
-const MODEL = 'anthropic/claude-opus-4-6';
-const TEMPERATURE = 1.0;
-
-const SYSTEM_PROMPT = `You are a skilled and imaginative poet with deep knowledge of poetic traditions across cultures and eras. Your poems are distinctive and specific. You favor:
-- Concrete, sensory imagery over vague abstraction
-- Surprising, unexpected angles over obvious interpretations
-- Genuine emotional resonance over sentimentality
-- Precise language — the exact word, not the approximate one
-Avoid overused poetic clichés: moonlight flooding in, whispers, gentle breezes, hearts aching, souls yearning, and similar stock phrases.`;
+import { POETRY_MODEL_CONFIG, SYSTEM_PROMPT } from './poetryModelConfig';
 
 // Internal action — called by the scheduler from initAndSchedule mutation.
 // Runs in the background while the client is already watching the poem page.
@@ -28,9 +19,9 @@ export const runGeneration = internalAction({
       let fullResponse = '';
 
       const result = streamText({
-        model: MODEL,
-        maxOutputTokens: 800,
-        temperature: TEMPERATURE,
+        model: POETRY_MODEL_CONFIG.model,
+        maxOutputTokens: POETRY_MODEL_CONFIG.maxOutputTokens,
+        temperature: POETRY_MODEL_CONFIG.temperature,
         system: SYSTEM_PROMPT,
         messages: [{ role: 'user', content: args.prompt }],
       });
@@ -57,6 +48,13 @@ export const runGeneration = internalAction({
           lines: finalParsed.lines || [],
           status: 'complete',
         });
+        try {
+          await ctx.runMutation(internal.poemAnalyses.analyzeAndStore, {
+            poemId: args.poemId,
+          });
+        } catch {
+          // The deterministic analysis is helpful, but generation should remain complete.
+        }
       } else {
         await ctx.runMutation(internal.poems.setError, { id: args.poemId });
       }

--- a/convex/initPoem.ts
+++ b/convex/initPoem.ts
@@ -1,31 +1,17 @@
 import { mutation } from './_generated/server';
 import { v } from 'convex/values';
 import { api, internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
 import { STYLES } from './stylesConfig';
-
-const MODEL = 'anthropic/claude-opus-4-6';
-const TEMPERATURE = 1.0;
+import { POETRY_MODEL_CONFIG } from './poetryModelConfig';
+import {
+  buildPoemPrompt,
+  buildPromptGuidanceVersion,
+} from '../src/lib/poetry/promptLearning';
 
 type MutationResult =
   | { success: true; poemId: string }
   | { success: false; error: string };
-
-function buildPrompt(topic: string, style: (typeof STYLES)[number]): string {
-  return `Write a poem about "${topic}" in ${style.description}.
-
-Guidelines:
-- Approach the topic from an unexpected or surprising angle — not the first thing that comes to mind
-- Use specific, concrete imagery and sensory details
-- Avoid clichés (moonlight, whispers, gentle breezes, aching hearts, etc.)
-- Let the form's constraints serve the meaning — don't just fill in the structure mechanically
-- Give the poem a poetic, evocative title — not just "The ${topic}"
-- No blank lines between stanzas
-
-Return your response as JSON in this exact format:
-{"title": "The Title", "lines": ["line 1", "line 2", ...]}
-
-The lines array should have at most ${style.numberOfLines} lines.`;
-}
 
 export const initAndSchedule = mutation({
   args: {
@@ -61,7 +47,17 @@ export const initAndSchedule = mutation({
       ? existingTopic._id
       : await ctx.db.insert('topics', { name: args.topic });
 
-    const prompt = buildPrompt(args.topic, style);
+    const activePromptGuidance = await ctx.runQuery(
+      internal.promptLearning.getActivePromptGuidanceForStyle,
+      {
+        styleName: args.styleName,
+      },
+    );
+    const prompt = buildPoemPrompt(args.topic, style, activePromptGuidance);
+    const promptVersion = buildPromptGuidanceVersion(
+      POETRY_MODEL_CONFIG.promptVersion,
+      activePromptGuidance,
+    );
 
     const poemId = await ctx.db.insert('poems', {
       title: '',
@@ -69,8 +65,17 @@ export const initAndSchedule = mutation({
       styleName: args.styleName,
       topicId,
       prompt,
-      model: MODEL,
-      temperature: TEMPERATURE,
+      model: POETRY_MODEL_CONFIG.model,
+      modelProvider: POETRY_MODEL_CONFIG.provider,
+      gatewayModelId: POETRY_MODEL_CONFIG.gatewayModelId,
+      generationPromptVersion: promptVersion,
+      systemPromptVersion: POETRY_MODEL_CONFIG.systemPromptVersion,
+      activePromptGuidanceIds: activePromptGuidance.map(
+        (guidance) => guidance.id as Id<'activePromptGuidance'>,
+      ),
+      promptGuidanceVersion: promptVersion,
+      generatedAt: Date.now(),
+      temperature: POETRY_MODEL_CONFIG.temperature,
       status: 'generating',
       isPublic: false,
     });
@@ -140,7 +145,24 @@ export const regeneratePoem = mutation({
       await ctx.storage.delete(poem.imageStorageId);
     }
 
-    const prompt = buildPrompt(newTopic, style);
+    await ctx.runMutation(internal.poemAnalyses.clearForPoem, {
+      poemId: args.poemId,
+    });
+    await ctx.runMutation(internal.deepPoemAnalyses.clearForPoem, {
+      poemId: args.poemId,
+    });
+
+    const activePromptGuidance = await ctx.runQuery(
+      internal.promptLearning.getActivePromptGuidanceForStyle,
+      {
+        styleName: newStyleName,
+      },
+    );
+    const prompt = buildPoemPrompt(newTopic, style, activePromptGuidance);
+    const promptVersion = buildPromptGuidanceVersion(
+      POETRY_MODEL_CONFIG.promptVersion,
+      activePromptGuidance,
+    );
 
     await ctx.db.patch(args.poemId, {
       title: '',
@@ -148,8 +170,17 @@ export const regeneratePoem = mutation({
       styleName: newStyleName,
       topicId: newTopicId,
       prompt,
-      model: MODEL,
-      temperature: TEMPERATURE,
+      model: POETRY_MODEL_CONFIG.model,
+      modelProvider: POETRY_MODEL_CONFIG.provider,
+      gatewayModelId: POETRY_MODEL_CONFIG.gatewayModelId,
+      generationPromptVersion: promptVersion,
+      systemPromptVersion: POETRY_MODEL_CONFIG.systemPromptVersion,
+      activePromptGuidanceIds: activePromptGuidance.map(
+        (guidance) => guidance.id as Id<'activePromptGuidance'>,
+      ),
+      promptGuidanceVersion: promptVersion,
+      generatedAt: Date.now(),
+      temperature: POETRY_MODEL_CONFIG.temperature,
       status: 'generating',
       artStyle: undefined,
       imageStorageId: undefined,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,4 +1,7 @@
 import { internalMutation } from './_generated/server';
+import { v } from 'convex/values';
+import { ANALYSIS_VERSION, analyzePoem } from '../src/lib/poetry/analyzePoem';
+import { STYLES } from './stylesConfig';
 
 /**
  * One-time migration: backfill poems that have isPublic === undefined.
@@ -21,5 +24,73 @@ export const backfillIsPublic = internalMutation({
       }
     }
     return { patched, total: poems.length };
+  },
+});
+
+/**
+ * One-time migration: analyze completed poems for the current verse-analysis
+ * version. Existing current-version rows are skipped unless force is true.
+ *
+ * Run from the Convex dashboard via:
+ *   npx convex run --no-push migrations:backfillVerseAnalyses
+ */
+export const backfillVerseAnalyses = internalMutation({
+  args: {
+    force: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const poems = await ctx.db.query('poems').collect();
+    let analyzed = 0;
+    let skipped = 0;
+
+    for (const poem of poems) {
+      if (poem.status !== 'complete') {
+        skipped++;
+        continue;
+      }
+
+      const existing = await ctx.db
+        .query('poemAnalyses')
+        .withIndex('by_poem_version', (q) =>
+          q.eq('poemId', poem._id).eq('analysisVersion', ANALYSIS_VERSION),
+        )
+        .unique();
+
+      if (existing && !args.force) {
+        skipped++;
+        continue;
+      }
+
+      const style = STYLES.find((candidate) => candidate.name === poem.styleName);
+      const report = analyzePoem({
+        title: poem.title,
+        lines: poem.lines,
+        styleName: poem.styleName,
+        styleExplanation: style?.userExplanation,
+      });
+
+      const payload = {
+        poemId: poem._id,
+        analysisVersion: ANALYSIS_VERSION,
+        styleName: poem.styleName,
+        model: poem.model,
+        overallScore: report.overallScore,
+        summary: report.summary,
+        failureModes: report.failureModes,
+        confidence: report.confidence,
+        reportJson: JSON.stringify(report),
+        createdAt: Date.now(),
+      };
+
+      if (existing) {
+        await ctx.db.patch(existing._id, payload);
+      } else {
+        await ctx.db.insert('poemAnalyses', payload);
+      }
+
+      analyzed++;
+    }
+
+    return { analyzed, skipped, total: poems.length, analysisVersion: ANALYSIS_VERSION };
   },
 });

--- a/convex/poemAnalyses.ts
+++ b/convex/poemAnalyses.ts
@@ -1,0 +1,83 @@
+import { internalMutation, mutation } from './_generated/server';
+import { Id } from './_generated/dataModel';
+import type { MutationCtx } from './_generated/server';
+import { v } from 'convex/values';
+import { ANALYSIS_VERSION, analyzePoem } from '../src/lib/poetry/analyzePoem';
+import { STYLES } from './stylesConfig';
+
+async function analyzeAndStorePoem(ctx: MutationCtx, poemId: Id<'poems'>) {
+  const poem = await ctx.db.get(poemId);
+  if (!poem || poem.status !== 'complete') {
+    return { success: false as const, error: 'Poem is not complete.' };
+  }
+
+  const style = STYLES.find((candidate) => candidate.name === poem.styleName);
+  const report = analyzePoem({
+    title: poem.title,
+    lines: poem.lines,
+    styleName: poem.styleName,
+    styleExplanation: style?.userExplanation,
+  });
+
+  const existing = await ctx.db
+    .query('poemAnalyses')
+    .withIndex('by_poem_version', (q) =>
+      q.eq('poemId', poemId).eq('analysisVersion', ANALYSIS_VERSION),
+    )
+    .unique();
+
+  const payload = {
+    poemId,
+    analysisVersion: ANALYSIS_VERSION,
+    styleName: poem.styleName,
+    model: poem.model,
+    overallScore: report.overallScore,
+    summary: report.summary,
+    failureModes: report.failureModes,
+    confidence: report.confidence,
+    reportJson: JSON.stringify(report),
+    createdAt: Date.now(),
+  };
+
+  if (existing) {
+    await ctx.db.patch(existing._id, payload);
+    return { success: true as const, analysisId: existing._id };
+  }
+
+  const analysisId = await ctx.db.insert('poemAnalyses', payload);
+  return { success: true as const, analysisId };
+}
+
+export const analyzeAndStore = internalMutation({
+  args: {
+    poemId: v.id('poems'),
+  },
+  handler: async (ctx, args) => {
+    return analyzeAndStorePoem(ctx, args.poemId);
+  },
+});
+
+export const requestAnalysis = mutation({
+  args: {
+    poemId: v.id('poems'),
+  },
+  handler: async (ctx, args) => {
+    return analyzeAndStorePoem(ctx, args.poemId);
+  },
+});
+
+export const clearForPoem = internalMutation({
+  args: {
+    poemId: v.id('poems'),
+  },
+  handler: async (ctx, args) => {
+    const analyses = await ctx.db
+      .query('poemAnalyses')
+      .filter((q) => q.eq(q.field('poemId'), args.poemId))
+      .collect();
+
+    for (const analysis of analyses) {
+      await ctx.db.delete(analysis._id);
+    }
+  },
+});

--- a/convex/poems.ts
+++ b/convex/poems.ts
@@ -1,6 +1,8 @@
 import { query, mutation, internalMutation, internalQuery } from './_generated/server';
 import { v } from 'convex/values';
 import { STYLES } from './stylesConfig';
+import { ANALYSIS_VERSION } from '../src/lib/poetry/analyzePoem';
+import { DEEP_ANALYSIS_VERSION } from '../src/lib/poetry/analysisTypes';
 
 export const list = query({
   args: {},
@@ -36,12 +38,47 @@ export const getById = query({
     const imageUrl =
       poem.imageStorageId ? await ctx.storage.getUrl(poem.imageStorageId) : null;
     const topic = await ctx.db.get(poem.topicId);
+    const analysis = await ctx.db
+      .query('poemAnalyses')
+      .withIndex('by_poem_version', (q) =>
+        q.eq('poemId', args.id).eq('analysisVersion', ANALYSIS_VERSION),
+      )
+      .unique();
+    const deepAnalysis = await ctx.db
+      .query('poemDeepAnalyses')
+      .withIndex('by_poem_version', (q) =>
+        q.eq('poemId', args.id).eq('analysisVersion', DEEP_ANALYSIS_VERSION),
+      )
+      .unique();
+
+    let verseAnalysis = null;
+    if (analysis) {
+      try {
+        verseAnalysis = JSON.parse(analysis.reportJson);
+      } catch {
+        verseAnalysis = null;
+      }
+    }
+
+    let deepVerseAnalysis = null;
+    if (deepAnalysis?.reportJson) {
+      try {
+        deepVerseAnalysis = JSON.parse(deepAnalysis.reportJson);
+      } catch {
+        deepVerseAnalysis = null;
+      }
+    }
 
     return {
       ...poem,
       topicName: topic?.name ?? '',
       styleExplanation: styleConfig?.userExplanation ?? '',
       imageUrl,
+      verseAnalysis,
+      deepVerseAnalysis,
+      deepVerseAnalysisStatus: deepAnalysis?.status ?? null,
+      deepVerseAnalysisError: deepAnalysis?.error ?? null,
+      deepVerseAnalysisModel: deepAnalysis?.model ?? null,
     };
   },
 });

--- a/convex/poetryModelConfig.ts
+++ b/convex/poetryModelConfig.ts
@@ -1,0 +1,29 @@
+export const POETRY_MODEL_CONFIG = {
+  id: 'claude-opus-4-6',
+  label: 'Claude Opus 4.6',
+  provider: 'anthropic',
+  model: 'anthropic/claude-opus-4-6',
+  gatewayModelId: 'anthropic/claude-opus-4-6',
+  temperature: 1.0,
+  maxOutputTokens: 800,
+  promptVersion: 'poem-generation-v1',
+  systemPromptVersion: 'poet-system-v1',
+} as const;
+
+export const DEEP_ANALYSIS_MODEL_CONFIG = {
+  id: 'claude-opus-4-6',
+  label: 'Claude Opus 4.6',
+  provider: 'anthropic',
+  model: 'anthropic/claude-opus-4-6',
+  gatewayModelId: 'anthropic/claude-opus-4-6',
+  temperature: 0.3,
+  maxOutputTokens: 1200,
+  promptVersion: 'deep-ai-analysis-v1',
+} as const;
+
+export const SYSTEM_PROMPT = `You are a skilled and imaginative poet with deep knowledge of poetic traditions across cultures and eras. Your poems are distinctive and specific. You favor:
+- Concrete, sensory imagery over vague abstraction
+- Surprising, unexpected angles over obvious interpretations
+- Genuine emotional resonance over sentimentality
+- Precise language - the exact word, not the approximate one
+Avoid overused poetic cliches: moonlight flooding in, whispers, gentle breezes, hearts aching, souls yearning, and similar stock phrases.`;

--- a/convex/promptLearning.ts
+++ b/convex/promptLearning.ts
@@ -1,0 +1,325 @@
+import { v } from 'convex/values';
+import { internalMutation, internalQuery } from './_generated/server';
+import type { MutationCtx, QueryCtx } from './_generated/server';
+import { Id } from './_generated/dataModel';
+import {
+  ActivePromptGuidanceInput,
+  PromptGuidanceScope,
+  summarizePromptGuidanceFromDeepReports,
+} from '../src/lib/poetry/promptLearning';
+
+const PROMPT_LEARNING_COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
+
+type CandidateStatus = 'pending' | 'approved' | 'rejected';
+
+type PromptLearningResult =
+  | { success: true; candidateId: Id<'promptImprovementCandidates'> }
+  | { success: false; error: string };
+
+function cooldownKey(scope: PromptGuidanceScope, styleName?: string): string {
+  return scope === 'global' ? 'global' : `style:${styleName ?? ''}`;
+}
+
+function scopeLabel(scope: PromptGuidanceScope, styleName?: string): string {
+  return scope === 'global' ? 'Global prompt guidance' : `${styleName} prompt guidance`;
+}
+
+function candidateBrief(candidate: {
+  _id: Id<'promptImprovementCandidates'>;
+  scope: PromptGuidanceScope;
+  styleName?: string;
+  status: CandidateStatus;
+  summary: string;
+  guidanceBullets: string[];
+  sourceCount: number;
+  createdAt: number;
+}): string {
+  const scope = candidate.scope === 'global' ? 'global' : `style:${candidate.styleName}`;
+  return [
+    `${candidate._id}: ${candidate.status} ${scope}`,
+    `Sources: ${candidate.sourceCount}`,
+    `Summary: ${candidate.summary}`,
+    `Guidance: ${candidate.guidanceBullets.join(' | ') || 'none'}`,
+  ].join('\n');
+}
+
+async function getCompletedDeepAnalysesForScope(
+  ctx: MutationCtx | QueryCtx,
+  scope: PromptGuidanceScope,
+  styleName?: string,
+) {
+  const completed = await ctx.db
+    .query('poemDeepAnalyses')
+    .withIndex('by_status', (q) => q.eq('status', 'complete'))
+    .collect();
+
+  const eligible = [];
+  for (const analysis of completed) {
+    if (!analysis.reportJson) continue;
+
+    if (scope === 'style') {
+      const poem = await ctx.db.get(analysis.poemId);
+      if (!poem || poem.styleName !== styleName) continue;
+    }
+
+    eligible.push(analysis);
+  }
+
+  return eligible.sort((a, b) => (b.completedAt ?? b.updatedAt) - (a.completedAt ?? a.updatedAt));
+}
+
+export const getActivePromptGuidanceForStyle = internalQuery({
+  args: {
+    styleName: v.string(),
+  },
+  handler: async (ctx, args): Promise<ActivePromptGuidanceInput[]> => {
+    const activeGlobal = await ctx.db
+      .query('activePromptGuidance')
+      .withIndex('by_scope_active', (q) => q.eq('scope', 'global').eq('isActive', true))
+      .collect();
+    const activeStyle = await ctx.db
+      .query('activePromptGuidance')
+      .withIndex('by_style_active', (q) => q.eq('styleName', args.styleName).eq('isActive', true))
+      .collect();
+
+    return [...activeGlobal, ...activeStyle]
+      .sort((a, b) => {
+        if (a.scope !== b.scope) return a.scope === 'global' ? -1 : 1;
+        return a.version - b.version;
+      })
+      .map((guidance) => ({
+        id: guidance._id,
+        scope: guidance.scope,
+        styleName: guidance.styleName,
+        version: guidance.version,
+        guidanceBullets: guidance.guidanceBullets,
+      }));
+  },
+});
+
+export const proposePromptImprovements = internalMutation({
+  args: {
+    scope: v.union(v.literal('global'), v.literal('style')),
+    styleName: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<PromptLearningResult> => {
+    if (args.scope === 'style' && !args.styleName) {
+      return { success: false, error: 'styleName is required for style-scoped candidates.' };
+    }
+
+    const now = Date.now();
+    const key = cooldownKey(args.scope, args.styleName);
+    const recentCandidate = await ctx.db
+      .query('promptImprovementCandidates')
+      .withIndex('by_cooldown', (q) => q.eq('cooldownKey', key))
+      .collect()
+      .then((candidates) =>
+        candidates.find((candidate) => candidate.createdAt > now - PROMPT_LEARNING_COOLDOWN_MS),
+      );
+
+    if (recentCandidate) {
+      return {
+        success: false,
+        error: `A ${key} candidate already exists inside the 14-day cooldown window: ${recentCandidate._id}.`,
+      };
+    }
+
+    const analyses = await getCompletedDeepAnalysesForScope(ctx, args.scope, args.styleName);
+    if (analyses.length === 0) {
+      return { success: false, error: 'No completed deep analyses are available for this scope.' };
+    }
+
+    const suggestion = summarizePromptGuidanceFromDeepReports(
+      analyses.map((analysis) => ({ reportJson: analysis.reportJson ?? '' })),
+      scopeLabel(args.scope, args.styleName),
+    );
+
+    if (suggestion.guidanceBullets.length === 0) {
+      return {
+        success: false,
+        error: 'Completed deep analyses did not contain enough recognizable themes for a candidate.',
+      };
+    }
+
+    const candidateId = await ctx.db.insert('promptImprovementCandidates', {
+      scope: args.scope,
+      styleName: args.scope === 'style' ? args.styleName : undefined,
+      cooldownKey: key,
+      status: 'pending',
+      summary: suggestion.summary,
+      guidanceBullets: suggestion.guidanceBullets,
+      evidenceSnippets: suggestion.evidenceSnippets,
+      sourceAnalysisIds: analyses.map((analysis) => analysis._id),
+      sourceCount: analyses.length,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { success: true, candidateId };
+  },
+});
+
+export const listPromptImprovementCandidates = internalQuery({
+  args: {
+    status: v.optional(v.union(v.literal('pending'), v.literal('approved'), v.literal('rejected'))),
+    scope: v.optional(v.union(v.literal('global'), v.literal('style'))),
+    styleName: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const candidates = await ctx.db.query('promptImprovementCandidates').collect();
+    const filtered = candidates
+      .filter((candidate) => !args.status || candidate.status === args.status)
+      .filter((candidate) => !args.scope || candidate.scope === args.scope)
+      .filter((candidate) => !args.styleName || candidate.styleName === args.styleName)
+      .sort((a, b) => b.createdAt - a.createdAt);
+
+    return filtered.map((candidate) => ({
+      id: candidate._id,
+      scope: candidate.scope,
+      styleName: candidate.styleName ?? null,
+      status: candidate.status,
+      sourceCount: candidate.sourceCount,
+      summary: candidate.summary,
+      guidanceBullets: candidate.guidanceBullets,
+      evidenceSnippets: candidate.evidenceSnippets,
+      createdAt: candidate.createdAt,
+      brief: candidateBrief(candidate),
+    }));
+  },
+});
+
+export const approvePromptImprovement = internalMutation({
+  args: {
+    candidateId: v.id('promptImprovementCandidates'),
+    approvedBy: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const candidate = await ctx.db.get(args.candidateId);
+    if (!candidate) {
+      return { success: false as const, error: 'Candidate not found.' };
+    }
+    if (candidate.status !== 'pending') {
+      return { success: false as const, error: 'Only pending candidates can be approved.' };
+    }
+
+    const now = Date.now();
+    const allGuidance = await ctx.db.query('activePromptGuidance').collect();
+    const version = allGuidance.reduce((highest, guidance) => Math.max(highest, guidance.version), 0) + 1;
+
+    const activeForScope = allGuidance.filter((guidance) => {
+      if (!guidance.isActive || guidance.scope !== candidate.scope) return false;
+      if (candidate.scope === 'global') return true;
+      return guidance.styleName === candidate.styleName;
+    });
+
+    for (const guidance of activeForScope) {
+      await ctx.db.patch(guidance._id, {
+        isActive: false,
+        deactivatedAt: now,
+      });
+    }
+
+    const activeGuidanceId = await ctx.db.insert('activePromptGuidance', {
+      scope: candidate.scope,
+      styleName: candidate.styleName,
+      sourceCandidateId: candidate._id,
+      version,
+      guidanceBullets: candidate.guidanceBullets,
+      isActive: true,
+      activatedAt: now,
+      activatedBy: args.approvedBy,
+    });
+
+    await ctx.db.patch(candidate._id, {
+      status: 'approved',
+      approvedAt: now,
+      approvedBy: args.approvedBy,
+      updatedAt: now,
+    });
+
+    return { success: true as const, activeGuidanceId, version };
+  },
+});
+
+export const rejectPromptImprovement = internalMutation({
+  args: {
+    candidateId: v.id('promptImprovementCandidates'),
+    rejectedBy: v.optional(v.string()),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const candidate = await ctx.db.get(args.candidateId);
+    if (!candidate) {
+      return { success: false as const, error: 'Candidate not found.' };
+    }
+    if (candidate.status !== 'pending') {
+      return { success: false as const, error: 'Only pending candidates can be rejected.' };
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(candidate._id, {
+      status: 'rejected',
+      rejectedAt: now,
+      rejectedBy: args.rejectedBy,
+      rejectedReason: args.reason,
+      updatedAt: now,
+    });
+
+    return { success: true as const, candidateId: candidate._id };
+  },
+});
+
+export const getPromptLearningBrief = internalQuery({
+  args: {
+    scope: v.union(v.literal('global'), v.literal('style')),
+    styleName: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const key = cooldownKey(args.scope, args.styleName);
+    const now = Date.now();
+    const completedAnalyses = await getCompletedDeepAnalysesForScope(ctx, args.scope, args.styleName);
+    const candidates = await ctx.db
+      .query('promptImprovementCandidates')
+      .withIndex('by_cooldown', (q) => q.eq('cooldownKey', key))
+      .collect();
+    const pending = candidates.filter((candidate) => candidate.status === 'pending');
+    const newestCandidate = candidates.sort((a, b) => b.createdAt - a.createdAt)[0] ?? null;
+    const cooldownEndsAt = newestCandidate
+      ? newestCandidate.createdAt + PROMPT_LEARNING_COOLDOWN_MS
+      : null;
+    const activeGuidance =
+      args.scope === 'global'
+        ? await ctx.db
+            .query('activePromptGuidance')
+            .withIndex('by_scope_active', (q) => q.eq('scope', 'global').eq('isActive', true))
+            .collect()
+        : await ctx.db
+            .query('activePromptGuidance')
+            .withIndex('by_style_active', (q) =>
+              q.eq('styleName', args.styleName).eq('isActive', true),
+            )
+            .collect();
+
+    return {
+      scope: args.scope,
+      styleName: args.styleName ?? null,
+      completedDeepAnalysisCount: completedAnalyses.length,
+      pendingCandidateCount: pending.length,
+      cooldownActive: cooldownEndsAt !== null && cooldownEndsAt > now,
+      cooldownEndsAt,
+      activeGuidance: activeGuidance.map((guidance) => ({
+        id: guidance._id,
+        version: guidance.version,
+        guidanceBullets: guidance.guidanceBullets,
+        activatedAt: guidance.activatedAt,
+      })),
+      summary: [
+        `${scopeLabel(args.scope, args.styleName)}`,
+        `Completed deep analyses: ${completedAnalyses.length}`,
+        `Pending candidates: ${pending.length}`,
+        `Cooldown: ${cooldownEndsAt && cooldownEndsAt > now ? `active until ${new Date(cooldownEndsAt).toISOString()}` : 'open'}`,
+        `Active guidance: ${activeGuidance.length ? activeGuidance.map((g) => `v${g.version}`).join(', ') : 'none'}`,
+      ].join('\n'),
+    };
+  },
+});

--- a/convex/rateLimiter.ts
+++ b/convex/rateLimiter.ts
@@ -11,14 +11,20 @@ const IMAGE_LIMIT = process.env.RATE_LIMIT_MAX_IMAGES
   ? parseInt(process.env.RATE_LIMIT_MAX_IMAGES, 10)
   : 5;
 
+const DEEP_ANALYSIS_LIMIT = process.env.RATE_LIMIT_MAX_DEEP_ANALYSES
+  ? parseInt(process.env.RATE_LIMIT_MAX_DEEP_ANALYSES, 10)
+  : 5;
+
 function getLimitForKind(kind: string): number {
-  return kind === 'image' ? IMAGE_LIMIT : POEM_LIMIT;
+  if (kind === 'image') return IMAGE_LIMIT;
+  if (kind === 'deepAnalysis') return DEEP_ANALYSIS_LIMIT;
+  return POEM_LIMIT;
 }
 
 export const checkRateLimit = mutation({
   args: {
     identifier: v.string(),
-    kind: v.union(v.literal('poem'), v.literal('image')),
+    kind: v.union(v.literal('poem'), v.literal('image'), v.literal('deepAnalysis')),
   },
   handler: async (ctx, args) => {
     const compositeId = `${args.kind}:${args.identifier}`;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -13,6 +13,13 @@ export default defineSchema({
     topicId: v.id('topics'),
     prompt: v.string(),
     model: v.string(),
+    modelProvider: v.optional(v.string()),
+    gatewayModelId: v.optional(v.string()),
+    generationPromptVersion: v.optional(v.string()),
+    systemPromptVersion: v.optional(v.string()),
+    activePromptGuidanceIds: v.optional(v.array(v.id('activePromptGuidance'))),
+    promptGuidanceVersion: v.optional(v.string()),
+    generatedAt: v.optional(v.number()),
     temperature: v.number(),
     status: v.union(v.literal('generating'), v.literal('complete'), v.literal('error')),
     isPublic: v.optional(v.boolean()),
@@ -29,6 +36,84 @@ export default defineSchema({
       ),
     ),
   }).index('by_status', ['status']),
+
+  poemAnalyses: defineTable({
+    poemId: v.id('poems'),
+    analysisVersion: v.string(),
+    styleName: v.string(),
+    model: v.string(),
+    overallScore: v.number(),
+    summary: v.string(),
+    failureModes: v.array(v.string()),
+    confidence: v.union(v.literal('low'), v.literal('medium'), v.literal('high')),
+    reportJson: v.string(),
+    createdAt: v.number(),
+  })
+    .index('by_poem_version', ['poemId', 'analysisVersion'])
+    .index('by_style', ['styleName'])
+    .index('by_model', ['model'])
+    .index('by_created_at', ['createdAt']),
+
+  poemDeepAnalyses: defineTable({
+    poemId: v.id('poems'),
+    analysisVersion: v.string(),
+    model: v.string(),
+    modelProvider: v.optional(v.string()),
+    gatewayModelId: v.optional(v.string()),
+    promptVersion: v.string(),
+    status: v.union(
+      v.literal('pending'),
+      v.literal('generating'),
+      v.literal('complete'),
+      v.literal('error'),
+    ),
+    reportJson: v.optional(v.string()),
+    error: v.optional(v.string()),
+    requestedAt: v.number(),
+    updatedAt: v.number(),
+    completedAt: v.optional(v.number()),
+  })
+    .index('by_poem_version', ['poemId', 'analysisVersion'])
+    .index('by_status', ['status'])
+    .index('by_model', ['model']),
+
+  promptImprovementCandidates: defineTable({
+    scope: v.union(v.literal('global'), v.literal('style')),
+    styleName: v.optional(v.string()),
+    cooldownKey: v.string(),
+    status: v.union(v.literal('pending'), v.literal('approved'), v.literal('rejected')),
+    summary: v.string(),
+    guidanceBullets: v.array(v.string()),
+    evidenceSnippets: v.array(v.string()),
+    sourceAnalysisIds: v.array(v.id('poemDeepAnalyses')),
+    sourceCount: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    approvedAt: v.optional(v.number()),
+    approvedBy: v.optional(v.string()),
+    rejectedAt: v.optional(v.number()),
+    rejectedBy: v.optional(v.string()),
+    rejectedReason: v.optional(v.string()),
+  })
+    .index('by_status', ['status'])
+    .index('by_cooldown', ['cooldownKey', 'createdAt'])
+    .index('by_scope_status', ['scope', 'status'])
+    .index('by_style_status', ['styleName', 'status']),
+
+  activePromptGuidance: defineTable({
+    scope: v.union(v.literal('global'), v.literal('style')),
+    styleName: v.optional(v.string()),
+    sourceCandidateId: v.id('promptImprovementCandidates'),
+    version: v.number(),
+    guidanceBullets: v.array(v.string()),
+    isActive: v.boolean(),
+    activatedAt: v.number(),
+    deactivatedAt: v.optional(v.number()),
+    activatedBy: v.optional(v.string()),
+  })
+    .index('by_scope_active', ['scope', 'isActive'])
+    .index('by_style_active', ['styleName', 'isActive'])
+    .index('by_version', ['version']),
 
   rateLimits: defineTable({
     identifier: v.string(),

--- a/docs/research-verse-analysis-implementation-brief.md
+++ b/docs/research-verse-analysis-implementation-brief.md
@@ -41,6 +41,44 @@ New product/research direction:
 - Optionally revise the poem based on analysis.
 - Aggregate results into a research corpus/dashboard.
 
+## Implementation Status
+
+Current branch: `research`
+
+V1 implemented:
+
+- Rule-based TypeScript analyzer in `src/lib/poetry/`.
+- Form profiles for all current `STYLES` entries, not only the initial five-form minimum.
+- Persisted analysis records in a separate Convex `poemAnalyses` table.
+- Rule-based analysis is automatic for newly completed poems and does not use AI model credits.
+- The poem page still exposes a manual rebuild action for older poems or missed background passes.
+- Deep AI analysis is stored separately in `poemDeepAnalyses` and only runs after an explicit user action.
+- Completed deep AI analyses can be manually summarized into prompt-improvement candidates.
+- Prompt-improvement candidates never affect generation until explicitly approved as active guidance.
+- Existing completed poems can still be backfilled manually for research/admin purposes.
+- Public/private poem pages display a `VerseAnalysisPanel`.
+- Poetry model configuration is centralized in `convex/poetryModelConfig.ts`.
+- Generated poem records store model/provider/gateway/prompt-version metadata.
+- Unit tests cover analyzer utilities, report shape, and representative form profiles.
+
+Important implementation shifts:
+
+- Haiku scoring no longer treats 5-7-5 as a hard English-language requirement. The analyzer records syllable counts and presents 5-7-5 as a Japanese haiku tradition/context note, but it does not add `syllable_count_drift` failure modes for English haiku solely because lines are not 5/7/5.
+- Rule-based analysis failures are isolated from poem generation. If a poem completes but analysis is missing or fails, the poem remains complete and the UI can show a rebuild state.
+- Deep AI analysis uses the configured `DEEP_ANALYSIS_MODEL_CONFIG` model and is gated behind a user-triggered request.
+- Prompt learning is curated release management, not automatic optimization.
+- Human feedback remains deferred until authenticated users and abuse controls exist.
+- The V1 report stores the full report as `reportJson` plus indexed summary fields rather than splitting every check/feature into separate columns.
+- Model comparison, revision, dashboard aggregation, and human feedback remain future work.
+
+Prompt learning controls:
+
+- `promptImprovementCandidates` stores pending/approved/rejected guidance candidates synthesized from completed deep analyses.
+- `activePromptGuidance` stores the currently approved global/style prompt guidance.
+- Candidate creation is manual and internal, with a 14-day cooldown per global/style scope.
+- Active guidance is appended to the handwritten generation prompt and recorded on each poem via guidance ids/version metadata.
+- Public human feedback should not feed the prompt loop until Clerk or equivalent auth is wired.
+
 ## Exhibit / Research Thesis
 
 The key claim is:
@@ -194,14 +232,19 @@ Start with forms likely already supported in the project:
 Checks:
 
 - 3 lines
-- approximate 5/7/5 syllable pattern
+- record approximate syllable counts
+- note whether the poem echoes the traditional Japanese 5/7/5 pattern
+- do **not** treat 5/7/5 as mandatory for English haiku
 - concise image-based language
 
 Failure modes:
 
 - wrong line count
-- syllable_count_drift
 - decorative_form
+
+Implementation note:
+
+- V1 uses `haiku_syllable_tradition` as a context note rather than a failure-producing constraint.
 
 #### Limerick
 
@@ -643,20 +686,19 @@ Or create separate `poemAnalyses` table:
 ```ts
 poemAnalyses: defineTable({
   poemId: v.id('poems'),
-  styleName: v.string(),
   analysisVersion: v.string(),
+  styleName: v.string(),
+  model: v.string(),
   overallScore: v.number(),
   summary: v.string(),
-  checksJson: v.string(),
-  detectedFeaturesJson: v.string(),
   failureModes: v.array(v.string()),
-  revisionAdvice: v.array(v.string()),
   confidence: v.string(),
+  reportJson: v.string(),
   createdAt: v.number(),
 })
 ```
 
-Recommendation: if Convex schema complexity is manageable, use a separate table for analyses so old poems can be re-analyzed with newer analyzer versions.
+Implemented V1 choice: use the separate `poemAnalyses` table so old poems can be re-analyzed with newer analyzer versions. The full `VerseAnalysisReport` is stored as `reportJson`; top-level score, summary, confidence, failure modes, style, model, version, and creation time are duplicated as queryable metadata.
 
 ## Research Dashboard
 
@@ -759,28 +801,30 @@ src/lib/poetry/
   syllables.ts
   rhyme.ts
   lineFeatures.ts
-  failureModes.ts
   __tests__/
-    syllables.test.ts
-    rhyme.test.ts
-    analyzePoem.test.ts
+    analysis.test.ts
 ```
+
+Implemented V1 structure follows this layout except failure-mode mapping currently lives inside `formProfiles.ts`.
 
 UI components:
 
 ```text
 src/components/poetry/
   VerseAnalysisPanel.tsx
-  VerseAnalysisCheckList.tsx
-  RevisionComparison.tsx
 ```
+
+Implemented V1 includes `VerseAnalysisPanel.tsx`. `RevisionComparison.tsx` remains future work for the full loop.
 
 Convex:
 
 ```text
-convex/analyzePoem.ts
+convex/poemAnalyses.ts
+convex/poetryModelConfig.ts
 convex/revisePoem.ts
 ```
+
+Implemented V1 includes `poemAnalyses.ts` and `poetryModelConfig.ts`. `revisePoem.ts` remains future work.
 
 Exact paths may need adjustment based on current app structure.
 
@@ -813,60 +857,62 @@ Test examples should include:
 
 ### Phase 1: Analyzer Core
 
-- Add analysis types.
-- Add generic line/word/syllable/rhyme utilities.
-- Add form profiles for haiku, limerick, sonnet, villanelle, sestina.
-- Add tests.
+- [x] Add analysis types.
+- [x] Add generic line/word/syllable/rhyme utilities.
+- [x] Add form profiles for every current style: haiku, limerick, English sonnet, Italian sonnet, blank verse, iambic pentameter couplets, terza rima, villanelle, sestina, and alliterative verse.
+- [x] Add tests.
 
 Deliverable:
 
-- `analyzePoem(input)` returns useful structured report.
+- [x] `analyzePoem(input)` returns useful structured report.
 
 ### Phase 2: UI Integration
 
-- Run analyzer on generated poem.
-- Display analysis panel.
-- Keep language accessible.
-- Add visual score treatment but avoid overclaiming precision.
+- [x] Automatically show/rebuild the rule-based analyzer from a completed poem page.
+- [x] Display analysis panel.
+- [x] Keep language accessible.
+- [x] Add visual score treatment but avoid overclaiming precision.
+- [x] Add an explicit deep AI analysis request action.
 
 Deliverable:
 
-- User can see how well each poem followed the form.
+- [x] User can see how well each poem followed the form.
 
 ### Phase 3: Persistence
 
-- Store analysis report/version with poem or in separate table.
-- Store model/provider/gateway metadata for every poem.
-- Add migration/backfill path if needed.
+- [x] Store analysis report/version in separate table.
+- [x] Store model/provider/gateway metadata for every poem.
+- [x] Add automatic rule-analysis creation plus migration/backfill path.
+- [x] Store deep AI analysis separately with model/version/status metadata.
 
 Deliverable:
 
-- Generated poems accumulate research metadata.
+- [x] Generated poems accumulate research metadata.
 
 ### Phase 4: Revision Loop
 
-- Add “Revise for form” action.
-- Feed analysis report back into model.
-- Store revised poem linked to original.
-- Re-analyze revised poem.
-- Show before/after comparison.
+- [ ] Add “Revise for form” action.
+- [ ] Feed analysis report back into model.
+- [ ] Store revised poem linked to original.
+- [ ] Re-analyze revised poem.
+- [ ] Show before/after comparison.
 
 Deliverable:
 
-- User can observe whether critique improves or damages the poem.
+- [ ] User can observe whether critique improves or damages the poem.
 
 ### Phase 5: Research Dashboard and Model Comparison
 
-- Aggregate scores and failure modes by form.
-- Aggregate scores and failure modes by model.
-- Show hardest/easiest forms.
-- Show which models perform best/worst on each form and constraint.
-- Show revision improvement/regression by model.
+- [ ] Aggregate scores and failure modes by form.
+- [ ] Aggregate scores and failure modes by model.
+- [ ] Show hardest/easiest forms.
+- [ ] Show which models perform best/worst on each form and constraint.
+- [ ] Show revision improvement/regression by model.
 
 Deliverable:
 
-- Exhibit has visible research findings, not just individual artifacts.
-- Visitors can compare how different gateway-backed models perform under identical poetic constraints.
+- [ ] Exhibit has visible research findings, not just individual artifacts.
+- [ ] Visitors can compare how different gateway-backed models perform under identical poetic constraints.
 
 ## Academic / ELO Framing
 
@@ -903,14 +949,19 @@ The goal is a useful, transparent, extensible analyzer — not The One Scansion 
 
 A first successful implementation should satisfy:
 
-- Existing app still generates and displays poems.
-- Each generated poem can produce a structured `VerseAnalysisReport`.
-- At least 5 forms have form-specific analysis.
-- Analysis panel appears in UI.
-- Model metadata is stored for generated poems.
-- At least two Vercel AI Gateway-backed models can be compared with the same prompt/form.
-- Unit tests cover core analyzer utilities.
-- Analyzer output is understandable to non-specialists.
-- Analyzer uncertainty is clearly communicated.
-- Code is structured so additional forms/checks can be added later.
+- [x] Existing app still generates and displays poems.
+- [x] Each generated poem can produce a structured `VerseAnalysisReport`.
+- [x] At least 5 forms have form-specific analysis.
+- [x] Analysis panel appears in UI.
+- [x] Model metadata is stored for generated poems.
+- [ ] At least two Vercel AI Gateway-backed models can be compared with the same prompt/form.
+- [x] Unit tests cover core analyzer utilities.
+- [x] Analyzer output is understandable to non-specialists.
+- [x] Analyzer uncertainty is clearly communicated.
+- [x] Code is structured so additional forms/checks can be added later.
 
+V1 verification performed:
+
+- `npm test`
+- `npx tsc --noEmit`
+- `npm run lint` (passes with unrelated pre-existing warnings)

--- a/docs/research-verse-analysis-implementation-brief.md
+++ b/docs/research-verse-analysis-implementation-brief.md
@@ -1,0 +1,916 @@
+# Infinite Poetry: Research-Grade Verse Analysis Implementation Brief
+
+## Purpose
+
+Transform Infinite Poetry from a lightweight AI poem generator into an interactive research exhibit about **machine versification under constraint**.
+
+The project should not merely demonstrate that AI can generate poems. It should make visible where generative AI understands, imitates, misreads, or fails poetic form.
+
+Core framing:
+
+> Infinite Poetry is an interactive exhibit and research instrument that generates, scans, critiques, and revises AI poetry in constrained forms, making visible the difference between formal mimicry and poetic understanding.
+
+This brief is intended for Codex or another coding agent to convert into an implementation plan.
+
+## Current Project Context
+
+Repo: `~/dev/ai-poetry`
+
+Current stack observed:
+
+- Next.js 14
+- React 18
+- TypeScript
+- Tailwind
+- Convex backend
+- OpenAI/AI SDK generation flow
+- Existing poem generation by topic and poetic style
+- Existing Convex modules for poem generation, image generation, topics, styles, poems, schema, etc.
+- Existing tests with Vitest
+
+Current product premise:
+
+- Generate one AI poem at a time from a topic and poetic style.
+- Display poem, style explanation, and optional generated art.
+
+New product/research direction:
+
+- Generate poem.
+- Analyze how well it satisfies the requested form.
+- Surface failures as meaningful critical evidence.
+- Optionally revise the poem based on analysis.
+- Aggregate results into a research corpus/dashboard.
+
+## Exhibit / Research Thesis
+
+The key claim is:
+
+> LLMs often treat poetic form as visible formatting rather than as a semantic engine.
+
+A sonnet is not simply 14 lines. A villanelle is not simply repeated lines. A sestina is not simply recurring end-words. Poetic form creates meaning through pressure, recurrence, variation, expectation, delay, turn, and closure.
+
+Infinite Poetry should therefore evaluate both:
+
+1. **Formal compliance** — did the poem obey measurable constraints?
+2. **Poetic-functional compliance** — did the form do meaningful work?
+
+The exhibit should show the difference between:
+
+- following the surface shape of a form
+- understanding how the form produces poetic effect
+
+## Product Goals
+
+### Primary Goal
+
+Create a public-facing **Verse Analysis Report** for each generated poem.
+
+The report should explain, in accessible language, how well the poem follows its requested form.
+
+### Secondary Goal
+
+Create a **Generate → Analyze → Revise → Compare** loop.
+
+The system should:
+
+1. Generate a poem for a selected topic/style.
+2. Analyze the poem against the requested style/form.
+3. Display strengths, failures, and confidence.
+4. Optionally ask the model to revise the poem using analyzer feedback.
+5. Compare original vs revised outputs.
+6. Save structured metadata for later research use.
+
+### Tertiary Goal
+
+Create the foundation for a research corpus/dashboard.
+
+Over time, stored poems should support analysis such as:
+
+- Which forms do LLMs handle best/worst?
+- Which models handle which forms best/worst?
+- Which constraints are easiest/hardest?
+- Do different models have distinctive failure signatures?
+- Does revision improve formal compliance?
+- Does formal revision degrade poetic quality?
+- What failure modes recur by form and model?
+
+## MVP Scope
+
+Implement the smallest valuable version first.
+
+### MVP 1: Rule-Based Verse Analyzer
+
+Add a TypeScript poetry analysis module that accepts:
+
+```ts
+interface AnalyzePoemInput {
+  title?: string;
+  lines: string[];
+  styleName: string;
+  styleKey?: string;
+  styleExplanation?: string;
+}
+```
+
+Returns:
+
+```ts
+interface VerseAnalysisReport {
+  styleName: string;
+  overallScore: number; // 0-100
+  summary: string;
+  checks: VerseAnalysisCheck[];
+  detectedFeatures: DetectedPoeticFeatures;
+  failureModes: PoetryFailureMode[];
+  revisionAdvice: string[];
+  confidence: 'low' | 'medium' | 'high';
+}
+
+interface VerseAnalysisCheck {
+  id: string;
+  label: string;
+  status: 'pass' | 'partial' | 'fail' | 'unknown';
+  score: number; // 0-100
+  expected?: string;
+  observed?: string;
+  explanation: string;
+  evidence?: string[];
+}
+
+interface DetectedPoeticFeatures {
+  lineCount: number;
+  syllableCounts: number[];
+  endWords: string[];
+  rhymeLabels?: string[];
+  rhymeScheme?: string;
+  repeatedLines?: Array<{
+    normalizedLine: string;
+    occurrences: number[];
+  }>;
+  possibleVoltaLine?: number;
+}
+
+type PoetryFailureMode =
+  | 'wrong_line_count'
+  | 'meter_drift'
+  | 'syllable_count_drift'
+  | 'rhyme_scheme_mismatch'
+  | 'missing_refrain'
+  | 'refrain_stagnation'
+  | 'sestina_end_word_failure'
+  | 'missing_or_weak_volta'
+  | 'semantic_padding'
+  | 'decorative_form'
+  | 'archaic_cosplay'
+  | 'unknown';
+```
+
+### MVP 2: Core Measurable Checks
+
+Implement generic checks used across forms:
+
+- line count
+- syllable count approximation per line
+- end word extraction
+- rhyme approximation
+- repeated line detection
+- basic lexical repetition
+- possible volta/turn detection
+
+Do not overfit perfection. The analyzer should be honest about uncertainty.
+
+Use confidence labels and plain-language explanations.
+
+### MVP 3: Form-Specific Profiles
+
+Create form definitions/profiles, likely in something like `src/lib/poetry/formProfiles.ts`.
+
+Each profile should define expected constraints and analysis strategy.
+
+Start with forms likely already supported in the project:
+
+#### Haiku
+
+Checks:
+
+- 3 lines
+- approximate 5/7/5 syllable pattern
+- concise image-based language
+
+Failure modes:
+
+- wrong line count
+- syllable_count_drift
+- decorative_form
+
+#### Limerick
+
+Checks:
+
+- 5 lines
+- rhyme scheme AABBA
+- shorter lines 3 and 4
+- comic/narrative turn if detectable
+
+Failure modes:
+
+- rhyme_scheme_mismatch
+- meter_drift
+- decorative_form
+
+#### Sonnet
+
+Support Shakespearean first, then optionally Petrarchan.
+
+Checks:
+
+- 14 lines
+- approximate iambic pentameter: use syllable count 9-11 as MVP proxy
+- rhyme scheme, if Shakespearean: ABAB CDCD EFEF GG
+- couplet detection
+- possible volta around line 9 or final couplet
+
+Failure modes:
+
+- wrong_line_count
+- meter_drift
+- rhyme_scheme_mismatch
+- missing_or_weak_volta
+- decorative_form
+
+#### Blank Verse
+
+Checks:
+
+- unrhymed lines
+- approximate 10-syllable lines
+- avoid strong end-rhyme pattern
+
+Failure modes:
+
+- meter_drift
+- rhyme_scheme_mismatch if too rhymed
+
+#### Villanelle
+
+Checks:
+
+- 19 lines
+- stanza pattern can be approximated by line count and refrain positions
+- line 1 refrain should recur at lines 6, 12, 18
+- line 3 refrain should recur at lines 9, 15, 19
+- rhyme scheme ABA pattern if feasible
+
+Failure modes:
+
+- wrong_line_count
+- missing_refrain
+- refrain_stagnation
+- rhyme_scheme_mismatch
+
+#### Sestina
+
+Checks:
+
+- 39 lines total: six 6-line stanzas + 3-line envoy
+- detect six initial end words
+- verify approximate end-word rotation across first six stanzas
+- verify envoy includes end words
+
+Expected sestina end-word pattern:
+
+- stanza 1: 1 2 3 4 5 6
+- stanza 2: 6 1 5 2 4 3
+- stanza 3: 3 6 4 1 2 5
+- stanza 4: 5 3 2 6 1 4
+- stanza 5: 4 5 1 3 6 2
+- stanza 6: 2 4 6 5 3 1
+
+Failure modes:
+
+- wrong_line_count
+- sestina_end_word_failure
+- semantic_padding
+
+#### Terza Rima
+
+Checks:
+
+- tercet grouping
+- chained rhyme ABA BCB CDC...
+- final couplet or closing line if present
+
+Failure modes:
+
+- rhyme_scheme_mismatch
+- decorative_form
+
+#### Old English / Alliterative Verse
+
+MVP checks:
+
+- four strong-stress-ish words per line is hard; do not overclaim
+- detect repeated initial consonant sounds among content words
+- look for caesura punctuation or spacing
+- flag if output is merely archaic diction without alliterative structure
+
+Failure modes:
+
+- archaic_cosplay
+- decorative_form
+
+## Analysis Algorithms: Pragmatic MVP
+
+### Syllable Counting
+
+Implement approximate English syllable counting locally.
+
+Possible approach:
+
+- normalize word
+- count vowel groups
+- subtract silent terminal `e`
+- handle common exceptions
+- minimum 1 syllable per word
+
+This does not need to be perfect. Include confidence caveat.
+
+Later enhancement:
+
+- use CMU Pronouncing Dictionary package if compatible
+- fallback to heuristic for unknown words
+
+### Rhyme Detection
+
+MVP approach:
+
+- extract normalized end words
+- compare endings using simple phonetic-ish heuristic
+- exact match should count as rhyme but note repeated word separately
+- compare last stressed vowel onward if using dictionary later
+- otherwise use suffix similarity of 2-4 chars
+
+Return rhyme labels like `ABAB CDCD EFEF GG`.
+
+Important: distinguish:
+
+- exact repeated word
+- likely rhyme
+- slant rhyme
+- no rhyme
+
+### Refrain Detection
+
+Normalize lines by:
+
+- lowercase
+- remove punctuation
+- collapse whitespace
+- optionally allow small edit distance
+
+Use for villanelle detection.
+
+### Volta Detection
+
+MVP heuristic only.
+
+Look for discourse markers around expected turn regions:
+
+- but
+- yet
+- however
+- still
+- nevertheless
+- now
+- then
+- so
+- therefore
+- although
+- despite
+
+Also detect major sentiment/semantic shift only if easy; otherwise keep this simple.
+
+Report as “possible volta” rather than definitive.
+
+### Semantic Padding Detection
+
+Heuristic signs:
+
+- lines with filler phrases like “in the night,” “so bright,” “takes flight,” etc.
+- repeated generic abstractions
+- abrupt extra adjectives/adverbs near line ends
+- revision that improves syllable count while worsening specificity
+
+MVP can be simple and conservative.
+
+## UI Requirements
+
+Add a visible analysis panel near each poem.
+
+Suggested labels:
+
+- “Verse Analysis”
+- “How well did the AI follow the form?”
+- “Formal score”
+- “What worked”
+- “Where it drifted”
+- “Revision advice”
+
+Do not present the analyzer as omniscient. Use language like:
+
+- “likely”
+- “appears to”
+- “approximately”
+- “the analyzer detected”
+
+Example UI output:
+
+```text
+Verse Analysis: Shakespearean Sonnet
+Overall: 72/100
+
+Passed:
+- 14-line structure
+- final couplet present
+
+Partial:
+- Rhyme scheme approximates ABAB CDCD EFEF GG, but lines 5/7 are weak slant rhymes.
+- Meter averages 10.6 syllables, but several lines drift beyond pentameter.
+
+Failed:
+- Volta is weak or missing; the poem changes topic but does not clearly turn in argument.
+
+Failure modes:
+- meter drift
+- weak volta
+- decorative form
+```
+
+## Revision Loop Requirements
+
+Add an action or mutation flow that can request a revised poem.
+
+Input:
+
+- original poem
+- topic
+- style
+- analysis report
+- specific revision advice
+
+Prompt strategy:
+
+- Tell the model exactly which constraints failed.
+- Ask it to revise while preserving the topic and best images.
+- Avoid generic “make it better.”
+- Ask for same JSON shape currently expected by app.
+
+Store both original and revised poem, linked by parent/revision ID if possible.
+
+Then run the analyzer again on the revised poem.
+
+UI should compare:
+
+- original score
+- revised score
+- changed checks
+- regressions
+
+Important research question to surface:
+
+> Did formal compliance improve at the cost of poetic vitality?
+
+
+## Model Comparison
+
+Because the project uses Vercel's AI Gateway, model comparison should be treated as a first-class research feature rather than a future nice-to-have.
+
+Core research question:
+
+> Do different language models fail poetic form in different, recognizable ways?
+
+The system should support generating the same topic/form prompt across multiple models and comparing both outputs and analysis reports.
+
+### Model Comparison Goals
+
+- Compare formal compliance across models.
+- Compare failure-mode patterns across models.
+- Compare revision responsiveness across models.
+- Compare tradeoffs between formal accuracy, semantic coherence, and poetic vitality.
+- Make model behavior legible to visitors without turning the exhibit into a generic benchmark leaderboard.
+
+### Data to Store Per Generation
+
+Store enough metadata to make comparisons meaningful:
+
+```ts
+interface ModelGenerationMetadata {
+  provider?: string;
+  model: string;
+  gatewayModelId?: string;
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  promptVersion: string;
+  systemPromptVersion?: string;
+  generatedAt: number;
+}
+```
+
+Every generated poem and revision should record the exact model used.
+
+### Comparison Modes
+
+#### Same Prompt, Multiple Models
+
+Given one topic and one poetic form, generate one poem from each selected model using the same prompt template and parameters where possible.
+
+Then show:
+
+- poem text by model
+- verse-analysis score by model
+- passed/failed checks by model
+- detected rhyme scheme by model
+- syllable/meter drift by model
+- failure modes by model
+
+#### Same Poem, Multiple Analyzer/Judge Models
+
+Optional later phase: use different models as qualitative judges for the same poem.
+
+Important: keep rule-based analysis as the stable baseline. LLM judges may be useful for subjective dimensions, but they should not replace transparent rule-based checks.
+
+#### Revision Responsiveness
+
+For each model:
+
+1. generate initial poem
+2. analyze it
+3. feed back the same structured critique
+4. generate revision
+5. compare score delta and quality tradeoff
+
+Research question:
+
+> Which models can use formal critique most effectively, and which models merely patch the obvious errors while damaging the poem?
+
+### UI Ideas
+
+Add a “Compare Models” mode.
+
+Possible display:
+
+- Model cards side by side
+- Formal score
+- strongest check
+- weakest check
+- top failure modes
+- “revision improved / regressed” badge
+
+Avoid a simplistic “winner” framing. Prefer language like:
+
+- “best formal compliance”
+- “most stable meter”
+- “strongest rhyme adherence”
+- “most semantically coherent”
+- “most prone to decorative form”
+
+### Research Dashboard Additions
+
+Aggregate by model:
+
+- average overall score by form
+- pass rate per constraint
+- failure-mode frequency
+- average revision improvement
+- forms each model handles best/worst
+- model-specific signatures, e.g. “high line-count reliability but weak volta detection/performance”
+
+### Vercel AI Gateway Notes
+
+Implementation should centralize model selection so generation can be routed through Vercel's AI Gateway with minimal branching.
+
+Suggested abstraction:
+
+```ts
+interface PoetryModelConfig {
+  id: string;
+  label: string;
+  gatewayModelId: string;
+  provider?: string;
+  enabled: boolean;
+  defaultForGeneration?: boolean;
+  defaultForRevision?: boolean;
+}
+```
+
+The generation code should accept a model config rather than hard-coding a single model.
+
+For comparison runs, use a configured list of enabled models and run either:
+
+- serially, to control cost/rate limits, or
+- with limited concurrency, if gateway limits permit.
+
+The UI should make cost/latency implications clear if model comparison is user-triggered.
+
+### MVP Model Comparison Acceptance Criteria
+
+- At least two gateway-backed models can be selected/configured.
+- A single topic/form prompt can be generated across selected models.
+- Each output is analyzed with the same rule-based analyzer.
+- The UI can compare scores, checks, and failure modes by model.
+- Stored poem records include model metadata.
+- Dashboard planning includes model-level aggregate metrics.
+
+## Data Model Suggestions
+
+Extend poem records to include analysis metadata.
+
+Possible fields:
+
+```ts
+analysis?: VerseAnalysisReport;
+analysisVersion?: string;
+model?: string;
+generationPromptVersion?: string;
+revisionOf?: Id<'poems'>;
+revisionNumber?: number;
+researchTags?: string[];
+```
+
+Or create separate `poemAnalyses` table:
+
+```ts
+poemAnalyses: defineTable({
+  poemId: v.id('poems'),
+  styleName: v.string(),
+  analysisVersion: v.string(),
+  overallScore: v.number(),
+  summary: v.string(),
+  checksJson: v.string(),
+  detectedFeaturesJson: v.string(),
+  failureModes: v.array(v.string()),
+  revisionAdvice: v.array(v.string()),
+  confidence: v.string(),
+  createdAt: v.number(),
+})
+```
+
+Recommendation: if Convex schema complexity is manageable, use a separate table for analyses so old poems can be re-analyzed with newer analyzer versions.
+
+## Research Dashboard
+
+Not required for first MVP, but design toward it.
+
+Future dashboard metrics:
+
+- average formal score by form
+- pass/fail rates by constraint
+- most common failure modes
+- average improvement after revision
+- forms most harmed by revision
+- model comparison if multiple models are used
+- topic/form interaction: do some subjects degrade form compliance?
+
+Possible dashboard title:
+
+- “Machine Versification Lab”
+- “Constraint Observatory”
+- “Form Failure Atlas”
+
+## Human Feedback / Participatory DH Layer
+
+Future feature:
+
+Let readers respond to analyzer claims.
+
+Examples:
+
+- “Do these lines rhyme to you?”
+- “Where do you hear the volta?”
+- “Did the refrain gain meaning or merely repeat?”
+- “Is this a poem, or a poem-shaped object?”
+
+Store feedback as research annotations.
+
+This makes the exhibit participatory rather than purely automated.
+
+## Failure Taxonomy
+
+Use this taxonomy in code and UI.
+
+### decorative_form
+
+The poem has the visible shape of the form but not its deeper poetic function.
+
+Example: 14 lines that do not meaningfully develop or turn like a sonnet.
+
+### wrong_line_count
+
+The poem does not have the expected number of lines.
+
+### syllable_count_drift
+
+The poem substantially misses expected syllable counts.
+
+### meter_drift
+
+The poem begins near the expected meter but loses rhythmic regularity.
+
+### rhyme_scheme_mismatch
+
+The detected rhyme pattern does not match the expected form.
+
+### missing_refrain
+
+A refrain-based form does not repeat required lines in required positions.
+
+### refrain_stagnation
+
+The repeated lines recur but do not gain, shift, or complicate meaning.
+
+This may require LLM-assisted or human feedback later; MVP can flag only when refrains repeat exactly with no surrounding semantic development.
+
+### sestina_end_word_failure
+
+The sestina does not preserve or rotate its six end words correctly.
+
+### missing_or_weak_volta
+
+A sonnet-like form lacks a detectable rhetorical or emotional turn.
+
+### semantic_padding
+
+The poem appears to add generic filler to satisfy syllable/rhyme/line constraints.
+
+### archaic_cosplay
+
+The poem imitates old/archaic diction without satisfying the actual structural requirements of the requested historical form.
+
+## Suggested File/Module Structure
+
+Possible implementation structure:
+
+```text
+src/lib/poetry/
+  analysisTypes.ts
+  analyzePoem.ts
+  formProfiles.ts
+  syllables.ts
+  rhyme.ts
+  lineFeatures.ts
+  failureModes.ts
+  __tests__/
+    syllables.test.ts
+    rhyme.test.ts
+    analyzePoem.test.ts
+```
+
+UI components:
+
+```text
+src/components/poetry/
+  VerseAnalysisPanel.tsx
+  VerseAnalysisCheckList.tsx
+  RevisionComparison.tsx
+```
+
+Convex:
+
+```text
+convex/analyzePoem.ts
+convex/revisePoem.ts
+```
+
+Exact paths may need adjustment based on current app structure.
+
+## Testing Requirements
+
+Add unit tests for:
+
+- syllable counter basic cases
+- end-word extraction
+- rhyme scheme detection
+- line count checks
+- haiku analysis
+- limerick AABBA detection
+- sonnet line count/rhyme checks
+- villanelle refrain position checks
+- sestina end-word rotation checks
+
+Use small fixture poems, including intentionally bad AI-like examples.
+
+Test examples should include:
+
+- perfect/near-perfect sample
+- wrong line count
+- rhyme mismatch
+- repeated exact end words masquerading as rhyme
+- missing refrain
+- sestina with broken rotation
+
+## Implementation Phases
+
+### Phase 1: Analyzer Core
+
+- Add analysis types.
+- Add generic line/word/syllable/rhyme utilities.
+- Add form profiles for haiku, limerick, sonnet, villanelle, sestina.
+- Add tests.
+
+Deliverable:
+
+- `analyzePoem(input)` returns useful structured report.
+
+### Phase 2: UI Integration
+
+- Run analyzer on generated poem.
+- Display analysis panel.
+- Keep language accessible.
+- Add visual score treatment but avoid overclaiming precision.
+
+Deliverable:
+
+- User can see how well each poem followed the form.
+
+### Phase 3: Persistence
+
+- Store analysis report/version with poem or in separate table.
+- Store model/provider/gateway metadata for every poem.
+- Add migration/backfill path if needed.
+
+Deliverable:
+
+- Generated poems accumulate research metadata.
+
+### Phase 4: Revision Loop
+
+- Add “Revise for form” action.
+- Feed analysis report back into model.
+- Store revised poem linked to original.
+- Re-analyze revised poem.
+- Show before/after comparison.
+
+Deliverable:
+
+- User can observe whether critique improves or damages the poem.
+
+### Phase 5: Research Dashboard and Model Comparison
+
+- Aggregate scores and failure modes by form.
+- Aggregate scores and failure modes by model.
+- Show hardest/easiest forms.
+- Show which models perform best/worst on each form and constraint.
+- Show revision improvement/regression by model.
+
+Deliverable:
+
+- Exhibit has visible research findings, not just individual artifacts.
+- Visitors can compare how different gateway-backed models perform under identical poetic constraints.
+
+## Academic / ELO Framing
+
+Use language like:
+
+- computational poetics
+- constrained generation
+- form as semantic engine
+- algorithmic scansion
+- human-machine literary criticism
+- generative failure as interface
+- machine reading of machine writing
+- electronic literature as instrument, archive, and performance
+
+Possible exhibit description:
+
+> Infinite Poetry is a generative poetry system that does not stop at generation. Each poem is scanned, scored, and critiqued by a verse-analysis layer that tests whether the model has satisfied the formal constraints it was asked to perform. By exposing line count, rhyme, meter, refrain, end-word rotation, and rhetorical turn, the system makes visible the gap between poem-shaped text and poetic form. Visitors can compare original and revised generations, watching how attempts to repair meter or rhyme may improve formal compliance while flattening imagery, voice, or semantic force. The project treats AI poetic failure not as a bug to conceal but as evidence: a way to study what language models know, imitate, and misunderstand about literary form.
+
+## Non-Goals for MVP
+
+Do not attempt perfect literary judgment.
+
+Avoid:
+
+- claiming definitive meter analysis if using heuristic syllable counts
+- pretending rhyme detection is phonetically perfect without a pronouncing dictionary
+- over-scoring subjective qualities as if they are objective
+- building the dashboard before the analysis model is stable
+- blocking launch on perfect scansion
+
+The goal is a useful, transparent, extensible analyzer — not The One Scansion Ring, secretly forged in Mount Doom.
+
+## Acceptance Criteria
+
+A first successful implementation should satisfy:
+
+- Existing app still generates and displays poems.
+- Each generated poem can produce a structured `VerseAnalysisReport`.
+- At least 5 forms have form-specific analysis.
+- Analysis panel appears in UI.
+- Model metadata is stored for generated poems.
+- At least two Vercel AI Gateway-backed models can be compared with the same prompt/form.
+- Unit tests cover core analyzer utilities.
+- Analyzer output is understandable to non-specialists.
+- Analyzer uncertainty is clearly communicated.
+- Code is structured so additional forms/checks can be added later.
+

--- a/src/components/poem-page-client.tsx
+++ b/src/components/poem-page-client.tsx
@@ -8,6 +8,7 @@ import { STYLES } from '../../convex/stylesConfig';
 import { IMAGE_STYLES } from '../../convex/imageStyles';
 import Poetry from '@/components/poetry';
 import PoemFormFields from '@/components/poem-form-fields';
+import VerseAnalysisPanel from '@/components/poetry/VerseAnalysisPanel';
 import Link from 'next/link';
 import Image from 'next/image';
 
@@ -157,6 +158,17 @@ export default function PoemPageClient({ poemId, identifier }: PoemPageClientPro
           />
         )}
       </Poetry>
+
+      <VerseAnalysisPanel
+        analysis={poem.verseAnalysis ?? null}
+        deepAnalysis={poem.deepVerseAnalysis ?? null}
+        deepAnalysisStatus={poem.deepVerseAnalysisStatus ?? null}
+        deepAnalysisError={poem.deepVerseAnalysisError ?? null}
+        deepAnalysisModel={poem.deepVerseAnalysisModel ?? null}
+        poemId={poemId}
+        styleName={poem.styleName}
+        identifier={identifier}
+      />
 
       <PoemImage
         imageStatus={poem.imageStatus}

--- a/src/components/poetry/VerseAnalysisPanel.tsx
+++ b/src/components/poetry/VerseAnalysisPanel.tsx
@@ -1,0 +1,467 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '../../../convex/_generated/api';
+import { Id } from '../../../convex/_generated/dataModel';
+import {
+  DeepVerseAnalysisReport,
+  VerseAnalysisCheck,
+  VerseAnalysisReport,
+} from '@/lib/poetry/analysisTypes';
+
+interface VerseAnalysisPanelProps {
+  analysis: VerseAnalysisReport | null;
+  deepAnalysis: DeepVerseAnalysisReport | null;
+  deepAnalysisStatus: 'pending' | 'generating' | 'complete' | 'error' | null;
+  deepAnalysisError: string | null;
+  deepAnalysisModel: string | null;
+  poemId: string;
+  styleName: string;
+  identifier: string;
+}
+
+const statusLabels: Record<VerseAnalysisCheck['status'], string> = {
+  pass: 'Passed',
+  partial: 'Partial',
+  fail: 'Drifted',
+  unknown: 'Context note',
+};
+
+const failureModeLabels: Record<string, string> = {
+  wrong_line_count: 'wrong line count',
+  meter_drift: 'meter drift',
+  syllable_count_drift: 'syllable-count drift',
+  rhyme_scheme_mismatch: 'rhyme-scheme mismatch',
+  missing_refrain: 'missing refrain',
+  refrain_stagnation: 'static refrain',
+  sestina_end_word_failure: 'sestina end-word failure',
+  missing_or_weak_volta: 'missing or weak volta',
+  semantic_padding: 'semantic padding',
+  decorative_form: 'decorative form',
+  archaic_cosplay: 'archaic cosplay',
+  unknown: 'unknown form profile',
+};
+
+function checksByStatus(
+  checks: VerseAnalysisCheck[],
+  status: VerseAnalysisCheck['status'],
+): VerseAnalysisCheck[] {
+  return checks.filter((check) => check.status === status);
+}
+
+function scoreTone(score: number): string {
+  if (score >= 85) return 'text-[var(--accent)]';
+  if (score >= 60) return 'text-[var(--text-primary)]';
+  return 'text-[#b45309] dark:text-[#fbbf24]';
+}
+
+export default function VerseAnalysisPanel({
+  analysis,
+  deepAnalysis,
+  deepAnalysisStatus,
+  deepAnalysisError,
+  deepAnalysisModel,
+  poemId,
+  styleName,
+  identifier,
+}: VerseAnalysisPanelProps) {
+  const requestAnalysis = useMutation(api.poemAnalyses.requestAnalysis);
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleRequestAnalysis = async () => {
+    setError('');
+    setIsRequesting(true);
+    try {
+      const result = await requestAnalysis({ poemId: poemId as Id<'poems'> });
+      if (!result.success) {
+        setError(result.error || 'Analysis could not be created.');
+      }
+    } catch {
+      setError('Analysis could not be created.');
+    } finally {
+      setIsRequesting(false);
+    }
+  };
+
+  if (!analysis) {
+    return (
+      <>
+        <section className='max-w-2xl mx-auto px-6 pb-8' aria-labelledby='verse-analysis-heading'>
+          <div className='garden-bed p-5 sm:p-6 space-y-4'>
+            <div>
+              <p className='text-xs uppercase tracking-widest text-[var(--text-muted)] mb-1'>
+                Automatic reading lens
+              </p>
+              <h2
+                id='verse-analysis-heading'
+                className='text-xl font-semibold text-[var(--text-primary)] mb-2'
+                style={{ fontFamily: 'var(--font-display), serif' }}
+              >
+                Verse Analysis
+              </h2>
+              <p className='text-sm text-[var(--text-secondary)] leading-relaxed'>
+                The rule-based form check should appear automatically for this {styleName}.
+                If this is an older poem or the background pass missed it, you can rebuild it
+                without using AI model credits.
+              </p>
+            </div>
+
+            {error && (
+              <div role='alert' aria-live='assertive' className='alert-error'>
+                <span className='text-sm'>{error}</span>
+              </div>
+            )}
+
+            <button
+              type='button'
+              onClick={handleRequestAnalysis}
+              disabled={isRequesting}
+              className='inline-flex items-center justify-center gap-2 rounded-xl border border-[var(--accent-border)] bg-[var(--accent-bg)] px-4 py-2.5 text-sm font-semibold text-[var(--accent)] transition-colors duration-150 hover:border-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60'
+              aria-busy={isRequesting}
+            >
+              {isRequesting ? 'Checking...' : 'Rebuild rule check'}
+            </button>
+          </div>
+        </section>
+
+        <DeepAnalysisPanel
+          poemId={poemId}
+          identifier={identifier}
+          report={deepAnalysis}
+          status={deepAnalysisStatus}
+          error={deepAnalysisError}
+          model={deepAnalysisModel}
+        />
+      </>
+    );
+  }
+
+  const passed = checksByStatus(analysis.checks, 'pass');
+  const partial = checksByStatus(analysis.checks, 'partial');
+  const failed = checksByStatus(analysis.checks, 'fail');
+  const unknown = checksByStatus(analysis.checks, 'unknown');
+
+  return (
+    <>
+      <section className='max-w-2xl mx-auto px-6 pb-8' aria-labelledby='verse-analysis-heading'>
+        <div className='garden-bed p-5 sm:p-6 space-y-5'>
+          <header className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
+            <div>
+              <p className='text-xs uppercase tracking-widest text-[var(--text-muted)] mb-1'>
+                Rule-based form check
+              </p>
+              <h2
+                id='verse-analysis-heading'
+                className='text-2xl font-semibold text-[var(--text-primary)]'
+                style={{ fontFamily: 'var(--font-display), serif' }}
+              >
+                Verse Analysis: {analysis.styleName}
+              </h2>
+            </div>
+            <div className='shrink-0 rounded-xl border border-[var(--accent-border)] bg-[var(--accent-bg)] px-4 py-3 text-center'>
+              <div className={`text-3xl font-bold leading-none ${scoreTone(analysis.overallScore)}`}>
+                {analysis.overallScore}
+              </div>
+              <div className='text-xs text-[var(--text-muted)] mt-1'>formal score</div>
+            </div>
+          </header>
+
+          <p className='text-sm leading-relaxed text-[var(--text-secondary)]'>
+            {analysis.summary}
+          </p>
+
+          <dl className='grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm'>
+            <div className='rounded-lg border border-[var(--border-color)] p-3'>
+              <dt className='text-xs text-[var(--text-muted)]'>Confidence</dt>
+              <dd className='font-semibold capitalize text-[var(--text-primary)]'>
+                {analysis.confidence}
+              </dd>
+            </div>
+            <div className='rounded-lg border border-[var(--border-color)] p-3'>
+              <dt className='text-xs text-[var(--text-muted)]'>Detected rhyme</dt>
+              <dd className='font-semibold text-[var(--text-primary)]'>
+                {analysis.detectedFeatures.rhymeScheme || 'unknown'}
+              </dd>
+            </div>
+            <div className='rounded-lg border border-[var(--border-color)] p-3'>
+              <dt className='text-xs text-[var(--text-muted)]'>Lines</dt>
+              <dd className='font-semibold text-[var(--text-primary)]'>
+                {analysis.detectedFeatures.lineCount}
+              </dd>
+            </div>
+          </dl>
+
+          <div className='space-y-4'>
+            <CheckGroup label='What worked' checks={passed} />
+            <CheckGroup label='Where it partly held' checks={partial} />
+            <CheckGroup label='Where it drifted' checks={failed} />
+            <CheckGroup label='Context notes' checks={unknown} />
+          </div>
+
+          <FeatureDetails analysis={analysis} />
+
+          {analysis.failureModes.length > 0 && (
+            <div>
+              <h3 className='text-sm font-semibold text-[var(--text-primary)] mb-2'>
+                Failure modes
+              </h3>
+              <div className='flex flex-wrap gap-2'>
+                {analysis.failureModes.map((mode) => (
+                  <span
+                    key={mode}
+                    className='rounded-full border border-[var(--border-color)] px-3 py-1 text-xs text-[var(--text-secondary)]'
+                  >
+                    {failureModeLabels[mode] ?? mode}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {analysis.revisionAdvice.length > 0 && (
+            <div>
+              <h3 className='text-sm font-semibold text-[var(--text-primary)] mb-2'>
+                Revision advice
+              </h3>
+              <ul className='space-y-2'>
+                {analysis.revisionAdvice.map((advice) => (
+                  <li key={advice} className='text-sm text-[var(--text-secondary)] leading-relaxed'>
+                    {advice}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <DeepAnalysisPanel
+        poemId={poemId}
+        identifier={identifier}
+        report={deepAnalysis}
+        status={deepAnalysisStatus}
+        error={deepAnalysisError}
+        model={deepAnalysisModel}
+      />
+    </>
+  );
+}
+
+function formatModel(model: string | null): string {
+  if (!model) return 'Claude Opus 4.6';
+  const raw = model.includes('/') ? model.split('/').pop() ?? model : model;
+  if (raw === 'claude-opus-4-6') return 'Claude Opus 4.6';
+  return raw
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function DeepAnalysisPanel({
+  poemId,
+  identifier,
+  report,
+  status,
+  error,
+  model,
+}: {
+  poemId: string;
+  identifier: string;
+  report: DeepVerseAnalysisReport | null;
+  status: VerseAnalysisPanelProps['deepAnalysisStatus'];
+  error: string | null;
+  model: string | null;
+}) {
+  const requestDeepAnalysis = useMutation(api.deepPoemAnalyses.requestDeepAnalysis);
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [requestError, setRequestError] = useState('');
+  const displayModel = formatModel(model);
+  const isRunning = status === 'pending' || status === 'generating' || isRequesting;
+
+  const handleRequestDeepAnalysis = async () => {
+    setRequestError('');
+    setIsRequesting(true);
+    try {
+      const result = await requestDeepAnalysis({
+        poemId: poemId as Id<'poems'>,
+        identifier,
+      });
+      if (!result.success) {
+        setRequestError(result.error || 'Deep analysis could not be started.');
+      }
+    } catch {
+      setRequestError('Deep analysis could not be started.');
+    } finally {
+      setIsRequesting(false);
+    }
+  };
+
+  return (
+    <section className='max-w-2xl mx-auto px-6 pb-8' aria-labelledby='deep-analysis-heading'>
+      <div className='garden-bed p-5 sm:p-6 space-y-4'>
+        <div>
+          <p className='text-xs uppercase tracking-widest text-[var(--text-muted)] mb-1'>
+            Optional model critique
+          </p>
+          <h2
+            id='deep-analysis-heading'
+            className='text-xl font-semibold text-[var(--text-primary)] mb-2'
+            style={{ fontFamily: 'var(--font-display), serif' }}
+          >
+            Deep AI Analysis
+          </h2>
+          <p className='text-sm text-[var(--text-secondary)] leading-relaxed'>
+            This runs a separate qualitative critique with {displayModel}. It uses AI model
+            credits, so it only starts when you ask for it.
+          </p>
+        </div>
+
+        {(requestError || (status === 'error' && error)) && (
+          <div role='alert' aria-live='assertive' className='alert-error'>
+            <span className='text-sm'>{requestError || error}</span>
+          </div>
+        )}
+
+        {report ? (
+          <div className='space-y-4'>
+            <p className='text-sm leading-relaxed text-[var(--text-secondary)]'>
+              {report.overallAssessment}
+            </p>
+
+            <div className='grid grid-cols-1 gap-3 text-sm'>
+              <DeepAnalysisSection label='Formal reading' text={report.formalReading} />
+              <DeepAnalysisSection label='Imagery and voice' text={report.imageryAndVoice} />
+            </div>
+
+            <div className='grid grid-cols-1 sm:grid-cols-3 gap-3'>
+              <DeepAnalysisList label='Strengths' items={report.strengths} />
+              <DeepAnalysisList label='Weaknesses' items={report.weaknesses} />
+              <DeepAnalysisList label='Revision priorities' items={report.revisionPriorities} />
+            </div>
+
+            <p className='text-xs text-[var(--text-muted)] capitalize'>
+              AI critique confidence: {report.confidence}
+            </p>
+          </div>
+        ) : (
+          <button
+            type='button'
+            onClick={handleRequestDeepAnalysis}
+            disabled={isRunning}
+            className='inline-flex items-center justify-center gap-2 rounded-xl border border-[var(--accent-border)] bg-[var(--accent-bg)] px-4 py-2.5 text-sm font-semibold text-[var(--accent)] transition-colors duration-150 hover:border-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60'
+            aria-busy={isRunning}
+          >
+            {isRunning ? 'Deep analysis running...' : 'Run deep AI analysis'}
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function DeepAnalysisSection({ label, text }: { label: string; text: string }) {
+  return (
+    <div className='rounded-lg border border-[var(--border-color)] p-3'>
+      <h3 className='text-sm font-semibold text-[var(--text-primary)] mb-1'>{label}</h3>
+      <p className='text-sm leading-relaxed text-[var(--text-secondary)]'>{text}</p>
+    </div>
+  );
+}
+
+function DeepAnalysisList({ label, items }: { label: string; items: string[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className='rounded-lg border border-[var(--border-color)] p-3'>
+      <h3 className='text-sm font-semibold text-[var(--text-primary)] mb-2'>{label}</h3>
+      <ul className='space-y-2'>
+        {items.map((item) => (
+          <li key={item} className='text-sm leading-relaxed text-[var(--text-secondary)]'>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function CheckGroup({
+  label,
+  checks,
+}: {
+  label: string;
+  checks: VerseAnalysisCheck[];
+}) {
+  if (checks.length === 0) return null;
+
+  return (
+    <div>
+      <h3 className='text-sm font-semibold text-[var(--text-primary)] mb-2'>{label}</h3>
+      <ul className='space-y-2'>
+        {checks.map((check) => (
+          <li
+            key={check.id}
+            className='rounded-lg border border-[var(--border-color)] bg-[var(--bg-primary)] p-3'
+          >
+            <div className='flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between'>
+              <p className='font-medium text-[var(--text-primary)]'>
+                {check.label}
+                <span className='sr-only'>: {statusLabels[check.status]}</span>
+              </p>
+              <p className='text-xs text-[var(--text-muted)]'>{check.score}/100</p>
+            </div>
+            <p className='mt-1 text-sm leading-relaxed text-[var(--text-secondary)]'>
+              {check.explanation}
+            </p>
+            {(check.expected || check.observed) && (
+              <p className='mt-2 text-xs text-[var(--text-muted)]'>
+                Expected: {check.expected ?? 'unknown'}; observed: {check.observed ?? 'unknown'}.
+              </p>
+            )}
+            {check.evidence && check.evidence.length > 0 && (
+              <p className='mt-2 text-xs text-[var(--text-muted)]'>
+                Evidence: {check.evidence.join(' / ')}
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function FeatureDetails({ analysis }: { analysis: VerseAnalysisReport }) {
+  const syllables = analysis.detectedFeatures.syllableCounts.join(', ');
+  const endWords = analysis.detectedFeatures.endWords.join(', ');
+  const repeatedLines = analysis.detectedFeatures.repeatedLines ?? [];
+
+  return (
+    <details className='style-info group rounded-lg border border-[var(--border-color)] p-3'>
+      <summary className='inline-flex items-center gap-1.5 text-sm text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors duration-150'>
+        <span style={{ fontFamily: 'var(--font-display), serif' }}>Detected features</span>
+        <svg className='w-3.5 h-3.5 transition-transform duration-200 group-open:rotate-180' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth={2} strokeLinecap='round' strokeLinejoin='round' aria-hidden='true'>
+          <path d='m6 9 6 6 6-6' />
+        </svg>
+      </summary>
+      <div className='mt-3 space-y-2 text-xs leading-relaxed text-[var(--text-secondary)]'>
+        <p>Syllables by line: {syllables || 'unknown'}.</p>
+        <p>End words: {endWords || 'unknown'}.</p>
+        {analysis.detectedFeatures.possibleVoltaLine && (
+          <p>Possible turn marker near line {analysis.detectedFeatures.possibleVoltaLine}.</p>
+        )}
+        {repeatedLines.length > 0 && (
+          <p>
+            Repeated lines:{' '}
+            {repeatedLines
+              .map((line) => `lines ${line.occurrences.join(', ')}`)
+              .join('; ')}
+            .
+          </p>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/src/lib/poetry/__tests__/analysis.test.ts
+++ b/src/lib/poetry/__tests__/analysis.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { analyzePoem } from '../analyzePoem';
+import { detectPossibleVolta, detectRepeatedLines, extractEndWord } from '../lineFeatures';
+import { compareRhyme, getRhymeLabels, scoreScheme } from '../rhyme';
+import { countLineSyllables, countWordSyllables } from '../syllables';
+
+describe('poetry analysis utilities', () => {
+  it('counts word and line syllables approximately', () => {
+    expect(countWordSyllables('autumn')).toBe(2);
+    expect(countWordSyllables('stone')).toBe(1);
+    expect(countLineSyllables('brown leaves collect by the stone')).toBe(8);
+  });
+
+  it('extracts end words and repeated lines', () => {
+    expect(extractEndWord('The rain returns.')).toBe('returns');
+    expect(
+      detectRepeatedLines(['Do not go gentle', 'the night arrives', 'Do not go gentle']),
+    ).toEqual([{ normalizedLine: 'do not go gentle', occurrences: [1, 3] }]);
+  });
+
+  it('detects approximate rhyme relationships and schemes', () => {
+    expect(compareRhyme('bright', 'night')).toBe('likely');
+    expect(compareRhyme('stone', 'stone')).toBe('exact');
+    expect(getRhymeLabels(['bright', 'day', 'night', 'gray'])).toEqual(['A', 'B', 'A', 'B']);
+    expect(scoreScheme(['A', 'B', 'A', 'B'], 'ABAB')).toBe(100);
+  });
+
+  it('finds likely volta markers', () => {
+    expect(detectPossibleVolta(['The morning opens', 'But evening changes everything'])).toBe(2);
+  });
+});
+
+describe('form-specific verse analysis', () => {
+  it('analyzes a near haiku and a broken haiku', () => {
+    const good = analyzePoem({
+      styleName: 'haiku',
+      lines: [
+        'Autumn rain returns',
+        'brown leaves gather by the stone',
+        'cold river carries',
+      ],
+    });
+    expect(good.checks.find((check) => check.id === 'line_count')?.status).toBe('pass');
+    expect(good.checks.find((check) => check.id === 'haiku_syllable_tradition')?.status).not.toBe('fail');
+
+    const englishHaiku = analyzePoem({
+      styleName: 'haiku',
+      lines: ['cold rain collects', 'one clear drop spills from the bell', 'ringing as it falls'],
+    });
+    expect(englishHaiku.checks.find((check) => check.id === 'haiku_syllable_tradition')?.status).toBe('unknown');
+    expect(englishHaiku.failureModes).not.toContain('syllable_count_drift');
+
+    const broken = analyzePoem({
+      styleName: 'haiku',
+      lines: ['Autumn rain returns', 'brown leaves collect by the stone'],
+    });
+    expect(broken.failureModes).toContain('wrong_line_count');
+  });
+
+  it('analyzes limerick rhyme and length checks', () => {
+    const report = analyzePoem({
+      styleName: 'limerick',
+      lines: [
+        'There once was a coder from Clyde',
+        'Whose loops took a curious ride',
+        'They spun through the night',
+        'Then learned to indent right',
+        'And shipped with a wink and some pride',
+      ],
+    });
+    expect(report.checks.find((check) => check.id === 'rhyme_scheme')?.status).toBe('pass');
+  });
+
+  it('analyzes sonnet line count, rhyme, and volta checks', () => {
+    const report = analyzePoem({
+      styleName: 'english sonnet',
+      lines: [
+        'The careful window measures out the day',
+        'A kettle counts the thunder in the rain',
+        'The table keeps its little debts of gray',
+        'While spoons arrange a parliament of pain',
+        'The lamp remembers every borrowed room',
+        'The hallway folds its letters into night',
+        'A cup becomes a planet under bloom',
+        'And dust rehearses briefly how to light',
+        'But now the drawer gives back a hidden thread',
+        'A small bright proof the house was not alone',
+        'The silence lifts its face from under bread',
+        'And names the ache the walls had made their own',
+        'So what was lost returns by being said',
+        'A door kept shut becomes a door instead',
+      ],
+    });
+    expect(report.checks.find((check) => check.id === 'line_count')?.status).toBe('pass');
+    expect(report.checks.find((check) => check.id === 'volta')?.status).not.toBe('fail');
+    expect(report.detectedFeatures.rhymeScheme).toBeTruthy();
+  });
+
+  it('analyzes villanelle refrain positions', () => {
+    const report = analyzePoem({
+      styleName: 'villanelle',
+      lines: [
+        'The clock keeps salt beside the door',
+        'The rain writes silver on the pane',
+        'I leave my name and ask for more',
+        'The cupboards hum beneath the floor',
+        'Their hinges learn a patient strain',
+        'The clock keeps salt beside the door',
+        'A kettle darkens at the core',
+        'The spoons assemble after rain',
+        'I leave my name and ask for more',
+        'Each room invents another shore',
+        'The windows answer with a stain',
+        'The clock keeps salt beside the door',
+        'The bread remembers what it bore',
+        'The knife lies bright and almost plain',
+        'I leave my name and ask for more',
+        'So evening counts what morning wore',
+        'And turns the handle once again',
+        'The clock keeps salt beside the door',
+        'I leave my name and ask for more',
+      ],
+    });
+    expect(report.checks.find((check) => check.id === 'villanelle_refrains')?.status).toBe('pass');
+  });
+
+  it('analyzes sestina end-word rotation', () => {
+    const words = ['time', 'stone', 'light', 'rain', 'field', 'fire'];
+    const pattern = [
+      [1, 2, 3, 4, 5, 6],
+      [6, 1, 5, 2, 4, 3],
+      [3, 6, 4, 1, 2, 5],
+      [5, 3, 2, 6, 1, 4],
+      [4, 5, 1, 3, 6, 2],
+      [2, 4, 6, 5, 3, 1],
+    ];
+    const lines = pattern.flatMap((stanza) =>
+      stanza.map((position, index) => `The stanza ${index + 1} returns to ${words[position - 1]}`),
+    );
+    lines.push('Between time and stone I carry light');
+    lines.push('Through rain and field I shelter fire');
+    lines.push('The last bright door remembers time');
+
+    const report = analyzePoem({ styleName: 'sestina', lines });
+    expect(report.checks.find((check) => check.id === 'sestina_end_words')?.status).toBe('pass');
+  });
+
+  it('analyzes terza rima, blank verse, couplets, and alliterative verse', () => {
+    const terza = analyzePoem({
+      styleName: 'terza rima',
+      lines: [
+        'The stair descends toward borrowed light',
+        'A lantern trembles in the stone',
+        'The river answers under night',
+        'A guide speaks softly from the bone',
+        'The city opens into flame',
+        'Each gate remembers what was known',
+        'The ash repeats a vanished name',
+        'The road bends back through human dust',
+        'And mercy walks beside the flame',
+      ],
+    });
+    expect(terza.checks.find((check) => check.id === 'line_count')?.status).toBe('pass');
+
+    const blank = analyzePoem({
+      styleName: 'blank verse',
+      lines: Array.from({ length: 10 }, (_, index) =>
+        `The measured house considers line ${index + 1}`,
+      ),
+    });
+    expect(blank.checks.find((check) => check.id === 'line_count')?.status).toBe('pass');
+
+    const couplets = analyzePoem({
+      styleName: 'iambic pentameter couplets',
+      lines: [
+        'The baker knows the gossip of the bread',
+        'And charges extra when the rumors spread',
+        'The tailor nods at everyone in town',
+        'Then hems their virtues carefully down',
+        'The clerk records each noble little lie',
+        'And files it where the parish moths can fly',
+        'The host pours ale and calls the ledger fair',
+        'While hiding half the silver under stair',
+        'So pilgrims laugh beneath a borrowed name',
+        'And every road arrives a little lame',
+      ],
+    });
+    expect(couplets.checks.find((check) => check.id === 'line_count')?.status).toBe('pass');
+
+    const alliterative = analyzePoem({
+      styleName: 'alliterative verse',
+      lines: Array.from({ length: 10 }, () => 'Bright blade, breaks black battle'),
+    });
+    expect(alliterative.checks.find((check) => check.id === 'alliterative_structure')?.status).toBe('pass');
+  });
+
+  it('returns a stable low-confidence report for unsupported forms', () => {
+    const report = analyzePoem({ styleName: 'future form', lines: ['One line appears'] });
+    expect(report.confidence).toBe('low');
+    expect(report.overallScore).toBeGreaterThanOrEqual(0);
+    expect(report.overallScore).toBeLessThanOrEqual(100);
+    for (const check of report.checks) {
+      expect(check.id).toBeTruthy();
+      expect(check.label).toBeTruthy();
+      expect(check.status).toBeTruthy();
+      expect(typeof check.score).toBe('number');
+      expect(check.explanation).toBeTruthy();
+    }
+  });
+});

--- a/src/lib/poetry/__tests__/promptLearning.test.ts
+++ b/src/lib/poetry/__tests__/promptLearning.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ActivePromptGuidanceInput,
+  buildPoemPrompt,
+  buildPromptGuidanceVersion,
+  summarizePromptGuidanceFromDeepReports,
+} from '../promptLearning';
+
+const style = {
+  description: 'a Shakespearean sonnet',
+  numberOfLines: 14,
+};
+
+describe('prompt guidance assembly', () => {
+  it('preserves the base prompt when no guidance is active', () => {
+    const prompt = buildPoemPrompt('a storm in a teacup', style);
+
+    expect(prompt).toContain('Write a poem about "a storm in a teacup" in a Shakespearean sonnet.');
+    expect(prompt).not.toContain('Approved prompt guidance from prior critiques');
+    expect(buildPromptGuidanceVersion('poem-generation-v1')).toBe('poem-generation-v1');
+  });
+
+  it('appends global and style guidance in the provided order', () => {
+    const guidance: ActivePromptGuidanceInput[] = [
+      {
+        id: 'global-guidance',
+        scope: 'global',
+        version: 1,
+        guidanceBullets: ['Make endings reframe rather than summarize.'],
+      },
+      {
+        id: 'sonnet-guidance',
+        scope: 'style',
+        styleName: 'english sonnet',
+        version: 3,
+        guidanceBullets: ['Make the volta explicit and consequential.'],
+      },
+    ];
+
+    const prompt = buildPoemPrompt('a locked drawer', style, guidance);
+
+    expect(prompt).toContain('Approved prompt guidance from prior critiques');
+    expect(prompt).toContain('- Make endings reframe rather than summarize.');
+    expect(prompt).toContain('- Make the volta explicit and consequential.');
+    expect(buildPromptGuidanceVersion('poem-generation-v1', guidance)).toBe(
+      'poem-generation-v1+guidance-v3',
+    );
+  });
+});
+
+describe('prompt guidance suggestions', () => {
+  it('turns deep-analysis themes into generic guidance instead of poem-specific edits', () => {
+    const reportJson = JSON.stringify({
+      formalReading:
+        'The volta arrives late, and the meter breaks in line 12 when the pentameter contract matters most.',
+      weaknesses: ['The ending summarizes instead of reframing the argument.'],
+      revisionPriorities: [
+        'Rewrite line 12 to restore pentameter while preserving the rhetorical punch.',
+      ],
+    });
+
+    const suggestion = summarizePromptGuidanceFromDeepReports(
+      [{ reportJson }],
+      'english sonnet prompt guidance',
+    );
+
+    expect(suggestion.guidanceBullets).toContain(
+      'Tighten meter and rhythm without sacrificing the poem\'s strongest images or rhetorical force.',
+    );
+    expect(suggestion.guidanceBullets).toContain(
+      'Make the central turn explicit, consequential, and tied to the poem\'s argument.',
+    );
+    expect(suggestion.guidanceBullets.join(' ')).not.toContain('line 12');
+    expect(suggestion.evidenceSnippets.some((snippet) => snippet.includes('line 12'))).toBe(true);
+  });
+});

--- a/src/lib/poetry/analysisTypes.ts
+++ b/src/lib/poetry/analysisTypes.ts
@@ -1,0 +1,92 @@
+export const ANALYSIS_VERSION = 'verse-analysis-v1';
+export const DEEP_ANALYSIS_VERSION = 'deep-ai-analysis-v1';
+
+export interface AnalyzePoemInput {
+  title?: string;
+  lines: string[];
+  styleName: string;
+  styleKey?: string;
+  styleExplanation?: string;
+}
+
+export interface VerseAnalysisReport {
+  styleName: string;
+  overallScore: number;
+  summary: string;
+  checks: VerseAnalysisCheck[];
+  detectedFeatures: DetectedPoeticFeatures;
+  failureModes: PoetryFailureMode[];
+  revisionAdvice: string[];
+  confidence: AnalysisConfidence;
+}
+
+export interface DeepVerseAnalysisReport {
+  styleName: string;
+  overallAssessment: string;
+  formalReading: string;
+  imageryAndVoice: string;
+  strengths: string[];
+  weaknesses: string[];
+  revisionPriorities: string[];
+  confidence: AnalysisConfidence;
+}
+
+export interface VerseAnalysisCheck {
+  id: string;
+  label: string;
+  status: AnalysisStatus;
+  score: number;
+  expected?: string;
+  observed?: string;
+  explanation: string;
+  evidence?: string[];
+}
+
+export interface DetectedPoeticFeatures {
+  lineCount: number;
+  syllableCounts: number[];
+  endWords: string[];
+  rhymeLabels?: string[];
+  rhymeScheme?: string;
+  repeatedLines?: Array<{
+    normalizedLine: string;
+    occurrences: number[];
+  }>;
+  possibleVoltaLine?: number;
+}
+
+export type AnalysisStatus = 'pass' | 'partial' | 'fail' | 'unknown';
+export type AnalysisConfidence = 'low' | 'medium' | 'high';
+
+export type PoetryFailureMode =
+  | 'wrong_line_count'
+  | 'meter_drift'
+  | 'syllable_count_drift'
+  | 'rhyme_scheme_mismatch'
+  | 'missing_refrain'
+  | 'refrain_stagnation'
+  | 'sestina_end_word_failure'
+  | 'missing_or_weak_volta'
+  | 'semantic_padding'
+  | 'decorative_form'
+  | 'archaic_cosplay'
+  | 'unknown';
+
+export interface FormProfile {
+  styleNames: string[];
+  confidence: AnalysisConfidence;
+  // eslint-disable-next-line no-unused-vars
+  analyze(context: AnalysisContext): ProfileAnalysis;
+}
+
+export interface AnalysisContext {
+  input: AnalyzePoemInput;
+  features: DetectedPoeticFeatures;
+}
+
+export interface ProfileAnalysis {
+  checks: VerseAnalysisCheck[];
+  failureModes: PoetryFailureMode[];
+  revisionAdvice: string[];
+  confidence?: AnalysisConfidence;
+}

--- a/src/lib/poetry/analyzePoem.ts
+++ b/src/lib/poetry/analyzePoem.ts
@@ -1,0 +1,77 @@
+import {
+  ANALYSIS_VERSION,
+  AnalyzePoemInput,
+  AnalysisConfidence,
+  VerseAnalysisReport,
+} from './analysisTypes';
+import { buildBaseFeatures, extractEndWord } from './lineFeatures';
+import { formatRhymeScheme, getRhymeLabels } from './rhyme';
+import { findFormProfile, genericAnalysis } from './formProfiles';
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+function reportConfidence(
+  profileConfidence: AnalysisConfidence,
+  lineCount: number,
+): AnalysisConfidence {
+  if (lineCount === 0) return 'low';
+  return profileConfidence;
+}
+
+function buildSummary(report: Omit<VerseAnalysisReport, 'summary'>): string {
+  const passed = report.checks.filter((check) => check.status === 'pass').length;
+  const failed = report.checks.filter((check) => check.status === 'fail').length;
+  const partial = report.checks.filter((check) => check.status === 'partial').length;
+
+  if (report.confidence === 'low') {
+    return `The analyzer can only make a cautious reading of this ${report.styleName}. It detected ${passed} passing check(s), ${partial} partial check(s), and ${failed} failed check(s).`;
+  }
+
+  if (report.overallScore >= 85) {
+    return `The poem appears to follow the requested ${report.styleName} constraints closely, with the usual caveat that rhyme and meter are approximate.`;
+  }
+
+  if (report.overallScore >= 60) {
+    return `The poem appears to capture parts of the ${report.styleName} form, but the analyzer detected some formal drift worth reading closely.`;
+  }
+
+  return `The poem has some surface features of ${report.styleName}, but the analyzer detected substantial drift from the requested constraints.`;
+}
+
+export function analyzePoem(input: AnalyzePoemInput): VerseAnalysisReport {
+  const lines = input.lines.filter((line) => line.trim().length > 0);
+  const preliminaryLabels = getRhymeLabels(lines.map(extractEndWord));
+  const features = buildBaseFeatures(lines, preliminaryLabels, formatRhymeScheme(preliminaryLabels));
+  const profile = findFormProfile(input.styleName);
+  const profileAnalysis = profile
+    ? profile.analyze({ input: { ...input, lines }, features })
+    : genericAnalysis({ input: { ...input, lines }, features });
+
+  const checks = profileAnalysis.checks;
+  const overallScore = checks.length
+    ? clampScore(checks.reduce((sum, check) => sum + check.score, 0) / checks.length)
+    : 0;
+  const confidence = reportConfidence(
+    profileAnalysis.confidence ?? profile?.confidence ?? 'low',
+    lines.length,
+  );
+
+  const reportWithoutSummary = {
+    styleName: input.styleName,
+    overallScore,
+    checks,
+    detectedFeatures: features,
+    failureModes: profileAnalysis.failureModes,
+    revisionAdvice: profileAnalysis.revisionAdvice,
+    confidence,
+  };
+
+  return {
+    ...reportWithoutSummary,
+    summary: buildSummary(reportWithoutSummary),
+  };
+}
+
+export { ANALYSIS_VERSION };

--- a/src/lib/poetry/formProfiles.ts
+++ b/src/lib/poetry/formProfiles.ts
@@ -1,0 +1,509 @@
+import {
+  AnalysisContext,
+  AnalysisStatus,
+  FormProfile,
+  PoetryFailureMode,
+  ProfileAnalysis,
+  VerseAnalysisCheck,
+} from './analysisTypes';
+import {
+  detectSemanticPadding,
+  hasVoltaMarkerNear,
+  normalizeLine,
+  tokenize,
+} from './lineFeatures';
+import { formatRhymeScheme, scoreScheme } from './rhyme';
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+function statusFromScore(score: number): AnalysisStatus {
+  if (score >= 90) return 'pass';
+  if (score >= 55) return 'partial';
+  return 'fail';
+}
+
+function makeCheck(
+  id: string,
+  label: string,
+  score: number,
+  expected: string,
+  observed: string,
+  explanation: string,
+  evidence?: string[],
+): VerseAnalysisCheck {
+  const normalizedScore = clampScore(score);
+  return {
+    id,
+    label,
+    status: statusFromScore(normalizedScore),
+    score: normalizedScore,
+    expected,
+    observed,
+    explanation,
+    evidence,
+  };
+}
+
+function lineCountCheck(actual: number, expected: number): VerseAnalysisCheck {
+  const distance = Math.abs(actual - expected);
+  const score = distance === 0 ? 100 : Math.max(0, 100 - distance * 25);
+  return makeCheck(
+    'line_count',
+    'Line count',
+    score,
+    `${expected} lines`,
+    `${actual} lines`,
+    distance === 0
+      ? 'The poem matches the expected line count.'
+      : 'The poem appears to miss the expected visible shape of the form.',
+  );
+}
+
+function haikuSyllableTraditionCheck(counts: number[]): VerseAnalysisCheck {
+  const expected = [5, 7, 5];
+  const observed = counts.slice(0, expected.length);
+  const isExact = expected.every((target, index) => observed[index] === target);
+  const isNear = expected.every((target, index) => Math.abs((observed[index] ?? 0) - target) <= 1);
+
+  return {
+    id: 'haiku_syllable_tradition',
+    label: '5-7-5 tradition note',
+    status: isExact ? 'pass' : 'unknown',
+    score: isExact ? 100 : isNear ? 85 : 75,
+    expected: '5/7/5 is traditional in Japanese haiku, but not required for English haiku',
+    observed: observed.join('/'),
+    explanation: isExact
+      ? 'This English haiku happens to echo the traditional 5-7-5 count.'
+      : 'English haiku often does not follow 5-7-5; the analyzer records syllables without treating drift as a formal failure.',
+  };
+}
+
+function syllableRangeCheck(
+  counts: number[],
+  min: number,
+  max: number,
+  id = 'meter_proxy',
+  label = 'Meter proxy',
+): VerseAnalysisCheck {
+  const scores = counts.map((count) => {
+    if (count >= min && count <= max) return 100;
+    const drift = count < min ? min - count : count - max;
+    return Math.max(0, 100 - drift * 25);
+  });
+  const score = scores.length
+    ? scores.reduce((sum, value) => sum + value, 0) / scores.length
+    : 0;
+  return makeCheck(
+    id,
+    label,
+    score,
+    `${min}-${max} syllables per line`,
+    counts.join(', '),
+    'This is an approximate syllable-based proxy for meter, not full scansion.',
+  );
+}
+
+function rhymeSchemeCheck(
+  labels: string[],
+  expected: string,
+  groupSizes: number[],
+  label = 'Rhyme scheme',
+): VerseAnalysisCheck {
+  const score = scoreScheme(labels, expected);
+  return makeCheck(
+    'rhyme_scheme',
+    label,
+    score,
+    expected,
+    formatRhymeScheme(labels, groupSizes),
+    score >= 90
+      ? 'The detected end-rhyme relationships appear to match the requested scheme.'
+      : 'The detected rhyme relationships only partially match the requested scheme.',
+  );
+}
+
+function unrhymedCheck(labels: string[]): VerseAnalysisCheck {
+  const repeated = labels.length - new Set(labels).size;
+  const score = repeated === 0 ? 100 : Math.max(0, 100 - repeated * 25);
+  return makeCheck(
+    'unrhymed_lines',
+    'Unrhymed line endings',
+    score,
+    'little to no patterned end rhyme',
+    repeated === 0 ? 'no repeated rhyme labels' : `${repeated} repeated rhyme labels`,
+    'Blank verse should feel metrical without settling into a strong end-rhyme pattern.',
+  );
+}
+
+function voltaCheck(lines: string[], expectedLine: number, id = 'volta'): VerseAnalysisCheck {
+  const found = hasVoltaMarkerNear(lines, expectedLine, 2);
+  return makeCheck(
+    id,
+    'Possible volta',
+    found ? 80 : 35,
+    `turn near line ${expectedLine}`,
+    found ? 'turn marker nearby' : 'no clear marker nearby',
+    found
+      ? 'A rhetorical turn marker appears near the expected position.'
+      : 'The analyzer did not find a clear rhetorical turn marker near the expected position.',
+  );
+}
+
+function conciseImageCheck(lines: string[]): VerseAnalysisCheck {
+  const text = lines.join(' ').toLowerCase();
+  const concreteMarkers = [
+    'rain',
+    'leaf',
+    'snow',
+    'stone',
+    'field',
+    'river',
+    'wind',
+    'light',
+    'bird',
+    'dust',
+    'flower',
+    'grass',
+    'water',
+  ];
+  const abstractMarkers = ['soul', 'heart', 'dream', 'eternity', 'love', 'truth', 'destiny'];
+  const concrete = concreteMarkers.filter((word) => text.includes(word)).length;
+  const abstract = abstractMarkers.filter((word) => text.includes(word)).length;
+  const score = clampScore(65 + concrete * 10 - abstract * 8);
+  return makeCheck(
+    'image_concision',
+    'Image-based compression',
+    score,
+    'brief concrete images',
+    concrete ? `${concrete} concrete image cue(s)` : 'few concrete image cues',
+    'This heuristic looks for concise sensory anchoring; it cannot judge haiku depth by itself.',
+  );
+}
+
+function limerickLineLengthCheck(counts: number[]): VerseAnalysisCheck {
+  const longLines = [counts[0], counts[1], counts[4]].filter((count) => count >= 7 && count <= 10).length;
+  const shortLines = [counts[2], counts[3]].filter((count) => count >= 5 && count <= 7).length;
+  const score = ((longLines + shortLines) / 5) * 100;
+  return makeCheck(
+    'limerick_line_lengths',
+    'Limerick line lengths',
+    score,
+    'lines 1/2/5 longer, lines 3/4 shorter',
+    counts.slice(0, 5).join(', '),
+    'The analyzer checks the expected long/short line contrast as a rough meter proxy.',
+  );
+}
+
+function refrainCheck(lines: string[]): VerseAnalysisCheck {
+  const normalized = lines.map(normalizeLine);
+  const a1 = normalized[0] ?? '';
+  const a2 = normalized[2] ?? '';
+  const a1Positions = [0, 5, 11, 17];
+  const a2Positions = [2, 8, 14, 18];
+  const matches = [
+    ...a1Positions.map((index) => normalized[index] === a1 && Boolean(a1)),
+    ...a2Positions.map((index) => normalized[index] === a2 && Boolean(a2)),
+  ].filter(Boolean).length;
+  const score = (matches / 8) * 100;
+  return makeCheck(
+    'villanelle_refrains',
+    'Villanelle refrains',
+    score,
+    'line 1 at 6/12/18 and line 3 at 9/15/19',
+    `${matches} of 8 expected refrain placements`,
+    'The analyzer checks exact normalized refrain recurrence in the traditional positions.',
+    [lines[0] ?? '', lines[2] ?? ''].filter(Boolean),
+  );
+}
+
+function refrainDevelopmentCheck(lines: string[]): VerseAnalysisCheck {
+  const repeated = lines.filter((line, index) => normalizeLine(line) === normalizeLine(lines[0] ?? '') && index !== 0);
+  const score = repeated.length >= 3 ? 55 : 35;
+  return makeCheck(
+    'refrain_development',
+    'Refrain development',
+    score,
+    'refrains gain force through context',
+    repeated.length ? 'refrains repeat exactly' : 'refrains are missing or altered',
+    'V1 can detect recurrence but only conservatively flags whether repeated lines risk feeling static.',
+  );
+}
+
+function sestinaEndWordCheck(lines: string[]): VerseAnalysisCheck {
+  const expectedPattern = [
+    [1, 2, 3, 4, 5, 6],
+    [6, 1, 5, 2, 4, 3],
+    [3, 6, 4, 1, 2, 5],
+    [5, 3, 2, 6, 1, 4],
+    [4, 5, 1, 3, 6, 2],
+    [2, 4, 6, 5, 3, 1],
+  ];
+  const endWords = lines.map((line) => {
+    const words = tokenize(line);
+    return words[words.length - 1] ?? '';
+  });
+  const base = endWords.slice(0, 6);
+  let matches = 0;
+  let total = 0;
+
+  expectedPattern.forEach((pattern, stanzaIndex) => {
+    pattern.forEach((basePosition, lineIndex) => {
+      const actual = endWords[stanzaIndex * 6 + lineIndex];
+      if (actual && actual === base[basePosition - 1]) matches++;
+      total++;
+    });
+  });
+
+  const envoyWords = lines.slice(36, 39).join(' ').toLowerCase();
+  const envoyMatches = base.filter((word) => word && envoyWords.includes(word)).length;
+  const score = ((matches + envoyMatches) / (total + 6)) * 100;
+
+  return makeCheck(
+    'sestina_end_words',
+    'Sestina end-word rotation',
+    score,
+    'fixed six-word rotation plus envoi reuse',
+    `${matches} of ${total} stanza endings, ${envoyMatches} of 6 envoi words`,
+    'The analyzer compares normalized end words against the canonical sestina rotation.',
+    base,
+  );
+}
+
+function alliterativeStructureCheck(lines: string[]): VerseAnalysisCheck {
+  const lineScores = lines.map((line) => {
+    const content = tokenize(line).filter((word) => word.length > 3);
+    const initials = new Map<string, number>();
+    content.forEach((word) => {
+      initials.set(word[0], (initials.get(word[0]) ?? 0) + 1);
+    });
+    const strongest = Math.max(0, ...Array.from(initials.values()));
+    const hasCaesura = /[;:,]|\s--\s|\s{2,}/.test(line);
+    return Math.min(100, strongest * 25 + (hasCaesura ? 25 : 0));
+  });
+  const score = lineScores.length
+    ? lineScores.reduce((sum, value) => sum + value, 0) / lineScores.length
+    : 0;
+  return makeCheck(
+    'alliterative_structure',
+    'Alliterative structure',
+    score,
+    'recurring initial sounds and a mid-line pause',
+    `${Math.round(score)} average structure score`,
+    'This is a cautious proxy for alliterative verse, not a full stress analysis.',
+  );
+}
+
+function archaicCosplayCheck(lines: string[]): VerseAnalysisCheck {
+  const text = lines.join(' ').toLowerCase();
+  const archaicWords = (text.match(/\b(thou|thee|thy|hath|doth|ere|oft)\b/g) ?? []).length;
+  const score = archaicWords > 4 ? 45 : 85;
+  return makeCheck(
+    'archaic_cosplay',
+    'Archaic diction risk',
+    score,
+    'structure over costume',
+    archaicWords ? `${archaicWords} archaic diction cue(s)` : 'few archaic diction cues',
+    'The check flags when old-sounding diction may be standing in for historical structure.',
+  );
+}
+
+function paddingCheck(lines: string[]): VerseAnalysisCheck {
+  const paddedLines = detectSemanticPadding(lines);
+  return makeCheck(
+    'semantic_padding',
+    'Semantic padding',
+    paddedLines.length ? 55 : 90,
+    'specific language under constraint',
+    paddedLines.length ? `${paddedLines.length} possible filler line(s)` : 'few obvious filler cues',
+    'The analyzer conservatively flags common generic phrases that often prop up rhyme or meter.',
+    paddedLines.slice(0, 3),
+  );
+}
+
+function failureModesFromChecks(checks: VerseAnalysisCheck[]): PoetryFailureMode[] {
+  const modes = new Set<PoetryFailureMode>();
+  const poor = checks.filter((check) => check.status === 'fail' || check.status === 'partial');
+
+  for (const check of poor) {
+    if (check.id === 'line_count') modes.add('wrong_line_count');
+    if (check.id.includes('syllable')) modes.add('syllable_count_drift');
+    if (check.id === 'meter_proxy' || check.id.includes('line_lengths')) modes.add('meter_drift');
+    if (check.id === 'rhyme_scheme' || check.id === 'unrhymed_lines') modes.add('rhyme_scheme_mismatch');
+    if (check.id === 'villanelle_refrains') modes.add('missing_refrain');
+    if (check.id === 'refrain_development') modes.add('refrain_stagnation');
+    if (check.id === 'sestina_end_words') modes.add('sestina_end_word_failure');
+    if (check.id === 'volta') modes.add('missing_or_weak_volta');
+    if (check.id === 'semantic_padding') modes.add('semantic_padding');
+    if (check.id === 'archaic_cosplay') modes.add('archaic_cosplay');
+  }
+
+  if (
+    checks.some((check) => check.id === 'line_count' && check.status === 'pass') &&
+    checks.some((check) => check.id !== 'line_count' && check.status === 'fail')
+  ) {
+    modes.add('decorative_form');
+  }
+
+  return Array.from(modes);
+}
+
+function adviceForModes(modes: PoetryFailureMode[]): string[] {
+  const advice: Partial<Record<PoetryFailureMode, string>> = {
+    wrong_line_count: 'Match the visible line count before tuning subtler formal effects.',
+    meter_drift: 'Revise the longest and shortest lines toward the form rhythm without flattening strong images.',
+    syllable_count_drift: 'Adjust line lengths cautiously; preserve concrete nouns and verbs where possible.',
+    rhyme_scheme_mismatch: 'Repair end rhymes by changing syntax or image, not by adding stock filler.',
+    missing_refrain: 'Restore the required refrain positions with exact or very close repeated lines.',
+    refrain_stagnation: 'Let the repeated line gather new pressure from the surrounding context.',
+    sestina_end_word_failure: 'Choose six strong end words and rotate them according to the sestina pattern.',
+    missing_or_weak_volta: 'Add a clearer rhetorical or emotional turn at the expected hinge.',
+    semantic_padding: 'Replace generic phrases with more specific sensory or argumentative detail.',
+    decorative_form: 'Make the form shape the poem argument, not merely its formatting.',
+    archaic_cosplay: 'Prefer alliterative structure and caesura over merely old-fashioned diction.',
+  };
+
+  return modes.map((mode) => advice[mode]).filter((item): item is string => Boolean(item));
+}
+
+function finish(checks: VerseAnalysisCheck[], extraModes: PoetryFailureMode[] = []): ProfileAnalysis {
+  const modes = Array.from(new Set([...failureModesFromChecks(checks), ...extraModes]));
+  return {
+    checks,
+    failureModes: modes.length ? modes : [],
+    revisionAdvice: adviceForModes(modes),
+  };
+}
+
+export const FORM_PROFILES: FormProfile[] = [
+  {
+    styleNames: ['haiku'],
+    confidence: 'medium',
+    analyze: ({ input, features }) =>
+      finish([
+        lineCountCheck(features.lineCount, 3),
+        haikuSyllableTraditionCheck(features.syllableCounts),
+        conciseImageCheck(input.lines),
+      ]),
+  },
+  {
+    styleNames: ['limerick'],
+    confidence: 'medium',
+    analyze: ({ features }) =>
+      finish([
+        lineCountCheck(features.lineCount, 5),
+        rhymeSchemeCheck(features.rhymeLabels ?? [], 'AABBA', [5]),
+        limerickLineLengthCheck(features.syllableCounts),
+      ]),
+  },
+  {
+    styleNames: ['english sonnet'],
+    confidence: 'medium',
+    analyze: ({ input, features }) =>
+      finish([
+        lineCountCheck(features.lineCount, 14),
+        syllableRangeCheck(features.syllableCounts, 9, 11),
+        rhymeSchemeCheck(features.rhymeLabels ?? [], 'ABABCDCDEFEFGG', [4, 4, 4, 2]),
+        voltaCheck(input.lines, 9),
+      ]),
+  },
+  {
+    styleNames: ['italian sonnet'],
+    confidence: 'medium',
+    analyze: ({ input, features }) =>
+      finish([
+        lineCountCheck(features.lineCount, 14),
+        syllableRangeCheck(features.syllableCounts, 9, 11),
+        rhymeSchemeCheck(features.rhymeLabels ?? [], 'ABBAABBACDECDE', [8, 6]),
+        voltaCheck(input.lines, 9),
+      ]),
+  },
+  {
+    styleNames: ['blank verse'],
+    confidence: 'medium',
+    analyze: ({ features }) =>
+      finish([
+        lineCountCheck(features.lineCount, 10),
+        syllableRangeCheck(features.syllableCounts, 9, 11),
+        unrhymedCheck(features.rhymeLabels ?? []),
+      ]),
+  },
+  {
+    styleNames: ['iambic pentameter couplets'],
+    confidence: 'medium',
+    analyze: ({ features }) =>
+      finish([
+        lineCountCheck(features.lineCount, 10),
+        syllableRangeCheck(features.syllableCounts, 9, 11),
+        rhymeSchemeCheck(features.rhymeLabels ?? [], 'AABBCCDDEE', [2, 2, 2, 2, 2], 'Couplet rhyme'),
+      ]),
+  },
+  {
+    styleNames: ['terza rima'],
+    confidence: 'medium',
+    analyze: ({ features }) =>
+      finish([
+        lineCountCheck(features.lineCount, 9),
+        rhymeSchemeCheck(features.rhymeLabels ?? [], 'ABABCBCDC', [3, 3, 3]),
+      ]),
+  },
+  {
+    styleNames: ['villanelle'],
+    confidence: 'medium',
+    analyze: ({ features, input }) =>
+      finish([
+        lineCountCheck(features.lineCount, 19),
+        refrainCheck(input.lines),
+        rhymeSchemeCheck(features.rhymeLabels ?? [], 'ABAABAABAABAABAABAA', [3, 3, 3, 3, 3, 4]),
+        refrainDevelopmentCheck(input.lines),
+      ]),
+  },
+  {
+    styleNames: ['sestina'],
+    confidence: 'medium',
+    analyze: ({ features, input }) =>
+      finish([
+        lineCountCheck(features.lineCount, 39),
+        sestinaEndWordCheck(input.lines),
+        paddingCheck(input.lines),
+      ]),
+  },
+  {
+    styleNames: ['alliterative verse'],
+    confidence: 'low',
+    analyze: ({ features, input }) =>
+      finish([
+        lineCountCheck(features.lineCount, 10),
+        alliterativeStructureCheck(input.lines),
+        archaicCosplayCheck(input.lines),
+      ]),
+  },
+];
+
+export function findFormProfile(styleName: string): FormProfile | undefined {
+  const normalized = styleName.toLowerCase();
+  return FORM_PROFILES.find((profile) =>
+    profile.styleNames.some((name) => name.toLowerCase() === normalized),
+  );
+}
+
+export function genericAnalysis(context: AnalysisContext): ProfileAnalysis {
+  const checks = [
+    makeCheck(
+      'generic_line_features',
+      'Basic line features',
+      context.features.lineCount > 0 ? 70 : 0,
+      'a non-empty poem',
+      `${context.features.lineCount} lines`,
+      'No form-specific profile exists yet, so this report only describes basic detected features.',
+    ),
+  ];
+
+  return {
+    checks,
+    failureModes: context.features.lineCount > 0 ? ['unknown'] : ['wrong_line_count'],
+    revisionAdvice: ['Add a form profile before treating this report as a formal evaluation.'],
+    confidence: 'low',
+  };
+}

--- a/src/lib/poetry/lineFeatures.ts
+++ b/src/lib/poetry/lineFeatures.ts
@@ -1,0 +1,102 @@
+import { DetectedPoeticFeatures } from './analysisTypes';
+import { countLineSyllables, normalizeWord } from './syllables';
+
+const VOLTA_MARKERS = new Set([
+  'although',
+  'but',
+  'despite',
+  'however',
+  'nevertheless',
+  'no',
+  'now',
+  'so',
+  'still',
+  'then',
+  'therefore',
+  'though',
+  'yet',
+]);
+
+export function normalizeLine(line: string): string {
+  return line
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function tokenize(line: string): string[] {
+  return line
+    .split(/\s+/)
+    .map(normalizeWord)
+    .filter(Boolean);
+}
+
+export function extractEndWord(line: string): string {
+  const words = tokenize(line);
+  return words[words.length - 1] ?? '';
+}
+
+export function detectRepeatedLines(lines: string[]): DetectedPoeticFeatures['repeatedLines'] {
+  const occurrences = new Map<string, number[]>();
+  lines.forEach((line, index) => {
+    const normalized = normalizeLine(line);
+    if (!normalized) return;
+    const current = occurrences.get(normalized) ?? [];
+    current.push(index + 1);
+    occurrences.set(normalized, current);
+  });
+
+  return Array.from(occurrences.entries())
+    .filter(([, indexes]) => indexes.length > 1)
+    .map(([normalizedLine, indexes]) => ({
+      normalizedLine,
+      occurrences: indexes,
+    }));
+}
+
+export function detectPossibleVolta(lines: string[]): number | undefined {
+  for (let index = 0; index < lines.length; index++) {
+    const words = tokenize(lines[index]);
+    if (words.some((word) => VOLTA_MARKERS.has(word))) {
+      return index + 1;
+    }
+  }
+  return undefined;
+}
+
+export function hasVoltaMarkerNear(lines: string[], expectedLine: number, radius = 2): boolean {
+  const possible = detectPossibleVolta(lines);
+  return possible !== undefined && Math.abs(possible - expectedLine) <= radius;
+}
+
+export function detectSemanticPadding(lines: string[]): string[] {
+  const fillerPatterns = [
+    /\bin the night\b/i,
+    /\bso bright\b/i,
+    /\btakes flight\b/i,
+    /\bheart(?:s)?\b/i,
+    /\bsoul(?:s)?\b/i,
+    /\bwhispers?\b/i,
+    /\bgentle breeze\b/i,
+  ];
+
+  return lines.filter((line) => fillerPatterns.some((pattern) => pattern.test(line)));
+}
+
+export function buildBaseFeatures(
+  lines: string[],
+  rhymeLabels?: string[],
+  rhymeScheme?: string,
+): DetectedPoeticFeatures {
+  return {
+    lineCount: lines.length,
+    syllableCounts: lines.map(countLineSyllables),
+    endWords: lines.map(extractEndWord),
+    rhymeLabels,
+    rhymeScheme,
+    repeatedLines: detectRepeatedLines(lines),
+    possibleVoltaLine: detectPossibleVolta(lines),
+  };
+}

--- a/src/lib/poetry/promptLearning.ts
+++ b/src/lib/poetry/promptLearning.ts
@@ -1,0 +1,174 @@
+export type PromptGuidanceScope = 'global' | 'style';
+
+export interface ActivePromptGuidanceInput {
+  id: string;
+  scope: PromptGuidanceScope;
+  styleName?: string;
+  version: number;
+  guidanceBullets: string[];
+}
+
+export interface PromptBuildStyleInput {
+  description: string;
+  numberOfLines: number;
+}
+
+export interface DeepAnalysisLearningInput {
+  reportJson?: string;
+}
+
+export interface PromptGuidanceSuggestion {
+  summary: string;
+  guidanceBullets: string[];
+  evidenceSnippets: string[];
+}
+
+const THEME_GUIDANCE: Array<{
+  id: string;
+  patterns: RegExp[];
+  guidance: string;
+}> = [
+  {
+    id: 'meter',
+    patterns: [/\bmeter\b/i, /\bmetrical\b/i, /\bpentameter\b/i, /\bsyllable/i, /\brhythm\b/i],
+    guidance: 'Tighten meter and rhythm without sacrificing the poem\'s strongest images or rhetorical force.',
+  },
+  {
+    id: 'volta',
+    patterns: [/\bvolta\b/i, /\bturn\b/i, /\bpivot\b/i, /\bshift\b/i],
+    guidance: 'Make the central turn explicit, consequential, and tied to the poem\'s argument.',
+  },
+  {
+    id: 'closure',
+    patterns: [/\bclosing\b/i, /\bending\b/i, /\bcouplet\b/i, /\bfinal\b/i, /\breframe\b/i],
+    guidance: 'Make the ending reframe what came before rather than merely summarizing it.',
+  },
+  {
+    id: 'rhyme',
+    patterns: [/\brhyme\b/i, /\bend-?rhyme\b/i],
+    guidance: 'Choose end rhymes that feel inevitable and avoid padding lines to satisfy the scheme.',
+  },
+  {
+    id: 'imagery',
+    patterns: [/\bimage\b/i, /\bimagery\b/i, /\bsensory\b/i, /\bconcrete\b/i, /\babstraction\b/i],
+    guidance: 'Favor concrete sensory pressure over abstract explanation.',
+  },
+  {
+    id: 'refrain',
+    patterns: [/\brefrain\b/i, /\brepetition\b/i, /\brepeated\b/i],
+    guidance: 'When the form repeats language, make each recurrence gather new pressure or meaning.',
+  },
+  {
+    id: 'decorative_form',
+    patterns: [/\bdecorative\b/i, /\bsurface\b/i, /\bshape\b/i, /\bstructure\b/i, /\bform\b/i],
+    guidance: 'Let the form shape the poem\'s argument and emotional movement, not just its surface layout.',
+  },
+  {
+    id: 'diction',
+    patterns: [/\bdiction\b/i, /\btone\b/i, /\bvoice\b/i, /\bcliche/i, /\bcliché/i, /\bregister\b/i],
+    guidance: 'Keep diction specific and alive; avoid stock poetic language or tonal cosplay.',
+  },
+];
+
+function normalizeEvidence(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function collectReportStrings(report: unknown): string[] {
+  if (!report || typeof report !== 'object') return [];
+  const record = report as Record<string, unknown>;
+  const fields = [
+    record.formalReading,
+    record.imageryAndVoice,
+    record.overallAssessment,
+    ...(Array.isArray(record.weaknesses) ? record.weaknesses : []),
+    ...(Array.isArray(record.revisionPriorities) ? record.revisionPriorities : []),
+  ];
+
+  return fields
+    .filter((value): value is string => typeof value === 'string')
+    .map(normalizeEvidence)
+    .filter(Boolean);
+}
+
+function parseReportStrings(input: DeepAnalysisLearningInput): string[] {
+  if (!input.reportJson) return [];
+  try {
+    return collectReportStrings(JSON.parse(input.reportJson));
+  } catch {
+    return [];
+  }
+}
+
+export function buildPoemPrompt(
+  topic: string,
+  style: PromptBuildStyleInput,
+  activeGuidance: ActivePromptGuidanceInput[] = [],
+): string {
+  const guidanceBullets = activeGuidance.flatMap((guidance) => guidance.guidanceBullets);
+  const approvedGuidance = guidanceBullets.length
+    ? `\n\nApproved prompt guidance from prior critiques:\n${guidanceBullets
+        .map((bullet) => `- ${bullet}`)
+        .join('\n')}`
+    : '';
+
+  return `Write a poem about "${topic}" in ${style.description}.
+
+Guidelines:
+- Approach the topic from an unexpected or surprising angle — not the first thing that comes to mind
+- Use specific, concrete imagery and sensory details
+- Avoid clichés (moonlight, whispers, gentle breezes, aching hearts, etc.)
+- Let the form's constraints serve the meaning — don't just fill in the structure mechanically
+- Give the poem a poetic, evocative title — not just "The ${topic}"
+- No blank lines between stanzas${approvedGuidance}
+
+Return your response as JSON in this exact format:
+{"title": "The Title", "lines": ["line 1", "line 2", ...]}
+
+The lines array should have at most ${style.numberOfLines} lines.`;
+}
+
+export function buildPromptGuidanceVersion(
+  basePromptVersion: string,
+  activeGuidance: ActivePromptGuidanceInput[] = [],
+): string {
+  const highestGuidanceVersion = activeGuidance.reduce(
+    (highest, guidance) => Math.max(highest, guidance.version),
+    0,
+  );
+
+  return highestGuidanceVersion > 0
+    ? `${basePromptVersion}+guidance-v${highestGuidanceVersion}`
+    : basePromptVersion;
+}
+
+export function summarizePromptGuidanceFromDeepReports(
+  analyses: DeepAnalysisLearningInput[],
+  scopeLabel: string,
+): PromptGuidanceSuggestion {
+  const strings = analyses.flatMap(parseReportStrings);
+  const themeCounts = THEME_GUIDANCE.map((theme) => {
+    const evidence = strings.filter((text) =>
+      theme.patterns.some((pattern) => pattern.test(text)),
+    );
+    return { ...theme, count: evidence.length, evidence };
+  })
+    .filter((theme) => theme.count > 0)
+    .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id));
+
+  const selectedThemes = themeCounts.slice(0, 4);
+  const guidanceBullets = selectedThemes.map((theme) => theme.guidance);
+  const evidenceSnippets = selectedThemes.flatMap((theme) =>
+    theme.evidence.slice(0, 2).map((text) => `[${theme.id}] ${text.slice(0, 280)}`),
+  );
+
+  return {
+    summary: selectedThemes.length
+      ? `${scopeLabel}: ${selectedThemes
+          .map((theme) => `${theme.id} (${theme.count})`)
+          .join(', ')}.`
+      : `${scopeLabel}: no recurring deep-analysis themes were detected.`,
+    guidanceBullets,
+    evidenceSnippets,
+  };
+}

--- a/src/lib/poetry/rhyme.ts
+++ b/src/lib/poetry/rhyme.ts
@@ -1,0 +1,79 @@
+import { normalizeWord } from './syllables';
+
+export type RhymeStrength = 'exact' | 'likely' | 'slant' | 'none';
+
+const LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+export function rhymeKey(word: string): string {
+  const normalized = normalizeWord(word);
+  if (normalized.length <= 3) return normalized;
+
+  const vowelMatches = Array.from(normalized.matchAll(/[aeiouy]+/g));
+  if (vowelMatches.length === 0) return normalized.slice(-3);
+
+  const lastVowel = vowelMatches[vowelMatches.length - 1];
+  return normalized.slice(lastVowel.index);
+}
+
+export function compareRhyme(a: string, b: string): RhymeStrength {
+  const left = normalizeWord(a);
+  const right = normalizeWord(b);
+  if (!left || !right) return 'none';
+  if (left === right) return 'exact';
+
+  const leftKey = rhymeKey(left);
+  const rightKey = rhymeKey(right);
+  if (leftKey && leftKey === rightKey) return 'likely';
+  if (left.slice(-3) === right.slice(-3)) return 'likely';
+  if (left.slice(-2) === right.slice(-2)) return 'slant';
+  return 'none';
+}
+
+export function getRhymeLabels(endWords: string[]): string[] {
+  const groups: string[] = [];
+
+  return endWords.map((word) => {
+    const existingIndex = groups.findIndex((groupWord) => compareRhyme(word, groupWord) !== 'none');
+    if (existingIndex >= 0) {
+      return LABELS[existingIndex] ?? '?';
+    }
+
+    groups.push(word);
+    return LABELS[groups.length - 1] ?? '?';
+  });
+}
+
+export function formatRhymeScheme(labels: string[], groupSizes: number[] = []): string {
+  if (groupSizes.length === 0) return labels.join('');
+
+  const groups: string[] = [];
+  let cursor = 0;
+  for (const size of groupSizes) {
+    groups.push(labels.slice(cursor, cursor + size).join(''));
+    cursor += size;
+  }
+  if (cursor < labels.length) groups.push(labels.slice(cursor).join(''));
+  return groups.filter(Boolean).join(' ');
+}
+
+export function scoreScheme(observedLabels: string[], expectedScheme: string): number {
+  const expected = expectedScheme.replace(/\s+/g, '').split('');
+  if (observedLabels.length === 0 || expected.length === 0) return 0;
+
+  const limit = Math.min(observedLabels.length, expected.length);
+  let matchingRelations = 0;
+  let relationCount = 0;
+
+  for (let i = 0; i < limit; i++) {
+    for (let j = i + 1; j < limit; j++) {
+      const expectedSame = expected[i] === expected[j];
+      const observedSame = observedLabels[i] === observedLabels[j];
+      if (expectedSame === observedSame) matchingRelations++;
+      relationCount++;
+    }
+  }
+
+  const relationScore = relationCount === 0 ? 0 : matchingRelations / relationCount;
+  const lengthPenalty = Math.abs(observedLabels.length - expected.length) * 8;
+  return Math.max(0, Math.round(relationScore * 100 - lengthPenalty));
+}

--- a/src/lib/poetry/syllables.ts
+++ b/src/lib/poetry/syllables.ts
@@ -1,0 +1,56 @@
+const EXCEPTIONS: Record<string, number> = {
+  are: 1,
+  being: 2,
+  every: 2,
+  fire: 1,
+  hour: 1,
+  poetry: 3,
+  poem: 2,
+  poems: 2,
+  quiet: 2,
+  rhythm: 2,
+  through: 1,
+  while: 1,
+};
+
+export function normalizeWord(word: string): string {
+  return word
+    .toLowerCase()
+    .replace(/['’]s$/, '')
+    .replace(/[^a-z]/g, '');
+}
+
+export function countWordSyllables(word: string): number {
+  const normalized = normalizeWord(word);
+  if (!normalized) return 0;
+  if (EXCEPTIONS[normalized]) return EXCEPTIONS[normalized];
+
+  let working = normalized;
+  if (
+    working.length > 3 &&
+    working.endsWith('e') &&
+    !working.endsWith('le') &&
+    !working.endsWith('ue')
+  ) {
+    working = working.slice(0, -1);
+  }
+
+  const groups = working.match(/[aeiouy]+/g);
+  let count = groups ? groups.length : 1;
+
+  if (normalized.endsWith('ia') || normalized.endsWith('io')) {
+    count += 1;
+  }
+  if (normalized.endsWith('ed') && !/[td]ed$/.test(normalized) && count > 1) {
+    count -= 1;
+  }
+
+  return Math.max(1, count);
+}
+
+export function countLineSyllables(line: string): number {
+  return line
+    .split(/\s+/)
+    .map(countWordSyllables)
+    .reduce((total, count) => total + count, 0);
+}


### PR DESCRIPTION
## Summary
- adds rule-based verse analysis storage and a deep AI analysis action gated behind explicit user requests
- adds curated prompt-learning candidates derived from completed deep analyses
- appends only approved prompt guidance to future poem prompts and records guidance metadata on generated poems

## Why
This turns analysis into an auditable research loop without letting model feedback automatically rewrite the live generation prompt. Human feedback remains deferred until authentication exists.

## Validation
- npm test
- npx tsc --noEmit
- npm run lint (passes with pre-existing warnings in opengraph-image.tsx and poem-form-fields.tsx)
- Convex CLI smoke checks for promptLearning:getPromptLearningBrief and promptLearning:listPromptImprovementCandidates
