### PR TITLE
[codex] Allow Dependabot runbook PR comments

### DIFF
--- a/.github/workflows/dependabot-failure-instructions.yml
+++ b/.github/workflows/dependabot-failure-instructions.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   comment:


### PR DESCRIPTION
## Summary
- Allows the Dependabot failure-instructions workflow to request pull request write permission.
- This should let the workflow post or update the Codex runbook comment when Dependabot PR CI fails.

## Validation
- Parsed workflow YAML successfully.